### PR TITLE
Add a basic integration test skeleton.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args:
           - --safe
           - --quiet
-        files: ^((custom_components)/.+)?[^/]+\.py$
+        files: ^((custom_components|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
     rev: v2.0.0
     hooks:
@@ -28,7 +28,7 @@ repos:
         additional_dependencies:
           - flake8-docstrings==1.5.0
           - pydocstyle==5.1.1
-        files: ^(custom_components)/.+\.py$
+        files: ^(custom_components|tests)/.+\.py$
   - repo: https://github.com/PyCQA/isort
     rev: 5.8.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+# Setup Development
+
+Environment setup:
+
+```
+$ python3 -m venv venv
+$ source venv/bin/activate
+$ pip3 install -r requirements_dev.txt
+$ pip3 install -r requirements_test.txt
+```
+
+Run tests:
+```
+$ pytest
+```

--- a/custom_components/__init__.py
+++ b/custom_components/__init__.py
@@ -1,0 +1,1 @@
+"""Custom components."""

--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -37,6 +37,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         nest = await client.authenticate(access_token)
     except Exception as exception:  # pylint: disable=broad-except
         LOGGER.exception(exception)
+        raise ConfigEntryNotReady from exception
 
     # Get initial first data (move later to coordinator)
     data = await client.get_first_data(nest.access_token, nest.userid)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,1 +1,1 @@
-pytest-homeassistant-custom-component==0.5.13
+pytest-homeassistant-custom-component==0.6.1

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Nest Protect integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,15 @@
 """Fixtures for testing."""
 
-from typing import Any, TypeVar
+from collections.abc import Awaitable, Callable, Generator
+from typing import TypeVar
 
-import pytest
-from collections.abc import Callable, Awaitable, Generator
-from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
-
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
-from custom_components.nest_protect.const import DOMAIN
 
+from custom_components.nest_protect.const import DOMAIN
 
 # Typing helpers
 ComponentSetup = Callable[[], Awaitable[None]]
@@ -24,6 +22,7 @@ REFRESH_TOKEN = "some-token"
 
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations) -> None:
+    """Enable custom integration."""
     yield
 
 
@@ -35,7 +34,8 @@ async def config_entry() -> MockConfigEntry:
 
 @pytest.fixture
 async def component_setup(
-    hass: HomeAssistant, config_entry: MockConfigEntry,
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
 ) -> YieldFixture[ComponentSetup]:
     """Fixture for setting up the component."""
     config_entry.add_to_hass(hass)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,57 @@
+"""Fixtures for testing."""
+
+from typing import Any, TypeVar
+
+import pytest
+from collections.abc import Callable, Awaitable, Generator
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.setup import async_setup_component
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from custom_components.nest_protect.const import DOMAIN
+
+
+# Typing helpers
+ComponentSetup = Callable[[], Awaitable[None]]
+T = TypeVar("T")
+YieldFixture = Generator[T, None, None]
+
+
+REFRESH_TOKEN = "some-token"
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations) -> None:
+    yield
+
+
+#@pytest.fixture
+#async def loop(event_loop: Any) -> Any:
+#    return event_loop
+
+
+@pytest.fixture
+async def config_entry() -> MockConfigEntry:
+    """Fixture to initialize a MockConfigEntry."""
+    return MockConfigEntry(domain=DOMAIN, data={"refresh_token": REFRESH_TOKEN})
+
+
+@pytest.fixture
+async def component_setup(
+    hass: HomeAssistant, config_entry: MockConfigEntry,
+) -> YieldFixture[ComponentSetup]:
+    """Fixture for setting up the component."""
+    config_entry.add_to_hass(hass)
+
+    async def func() -> None:
+        assert await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+    yield func
+
+    # Verify clean unload
+    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,11 +27,6 @@ def auto_enable_custom_integrations(enable_custom_integrations) -> None:
     yield
 
 
-#@pytest.fixture
-#async def loop(event_loop: Any) -> Any:
-#    return event_loop
-
-
 @pytest.fixture
 async def config_entry() -> MockConfigEntry:
     """Fixture to initialize a MockConfigEntry."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,49 @@
+"""Test init."""
+
+from unittest.mock import patch
+
+import aiohttp
+from homeassistant.config_entries import ConfigEntryState
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from .conftest import ComponentSetup
+
+REFRESH_TOKEN = "some-token"
+
+
+async def test_init(
+    hass, component_setup: ComponentSetup, config_entry: MockConfigEntry
+):
+    """Test initialization."""
+    with patch("custom_components.nest_protect.NestClient.get_access_token"), patch(
+        "custom_components.nest_protect.NestClient.authenticate"
+    ), patch("custom_components.nest_protect.NestClient.get_first_data"):
+        await component_setup()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_access_token_failure(
+    hass, component_setup: ComponentSetup, config_entry: MockConfigEntry
+):
+    """Test failure when getting an access token."""
+    with patch(
+        "custom_components.nest_protect.NestClient.get_access_token",
+        side_effect=aiohttp.ClientError(),
+    ):
+        await component_setup()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_authenticate_failure(
+    hass, component_setup: ComponentSetup, config_entry: MockConfigEntry
+):
+    """Test failure when authenticating."""
+    with patch("custom_components.nest_protect.NestClient.get_access_token"), patch(
+        "custom_components.nest_protect.NestClient.authenticate",
+        side_effect=aiohttp.ClientError(),
+    ):
+        await component_setup()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,8 +8,6 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from .conftest import ComponentSetup
 
-REFRESH_TOKEN = "some-token"
-
 
 async def test_init(
     hass, component_setup: ComponentSetup, config_entry: MockConfigEntry


### PR DESCRIPTION
Add a basic integration test skeleton to make it easier to extend the integration
with new features. Right now this just tests init and mocks out the client library,
but can be extended with actual interesting tests later.

Fix exception handling on startup so that it fails with retry instead of proceeding.