### PR TITLE
Add test coverage for pynest client library

### DIFF
--- a/custom_components/nest_protect/pynest/client.py
+++ b/custom_components/nest_protect/pynest/client.py
@@ -7,7 +7,14 @@ import urllib.parse
 
 from aiohttp import ClientSession, FormData
 
-from .const import CLIENT_ID, NEST_AUTH_URL_JWT, NEST_REQUEST, TOKEN_URL, USER_AGENT
+from .const import (
+    APP_LAUNCH_URL_FORMAT,
+    CLIENT_ID,
+    NEST_AUTH_URL_JWT,
+    NEST_REQUEST,
+    TOKEN_URL,
+    USER_AGENT,
+)
 from .models import NestResponse
 
 
@@ -148,7 +155,7 @@ class NestClient:
     async def get_first_data(self, nest_access_token: str, user_id: str) -> Any:
         """Get a Nest refresh token from an authorization code."""
         async with self.session.post(
-            f"https://home.nest.com/api/0.1/user/{user_id}/app_launch",
+            APP_LAUNCH_URL_FORMAT.format(user_id=user_id),
             json=NEST_REQUEST,
             headers={
                 "Authorization": f"Basic {nest_access_token}",

--- a/custom_components/nest_protect/pynest/const.py
+++ b/custom_components/nest_protect/pynest/const.py
@@ -11,6 +11,8 @@ TOKEN_URL = "https://oauth2.googleapis.com/token"
 # Client ID of the Nest iOS application
 CLIENT_ID = "733249279899-1gpkq9duqmdp55a7e5lft1pr2smumdla.apps.googleusercontent.com"
 
+# App launch API endpoint
+APP_LAUNCH_URL_FORMAT = "https://home.nest.com/api/0.1/user/{user_id}/app_launch"
 
 NEST_AUTH_URL_JWT = "https://nestauthproxyservice-pa.googleapis.com/v1/issue_jwt"
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-timeout = 15
+timeout = 10

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-timeout = 10
+timeout = 15

--- a/tests/pynest/__init__.py
+++ b/tests/pynest/__init__.py
@@ -1,0 +1,1 @@
+"""Test for pynest client library."""

--- a/tests/pynest/test_client.py
+++ b/tests/pynest/test_client.py
@@ -1,0 +1,114 @@
+"""Tests for NestClient."""
+from unittest.mock import patch
+
+from aiohttp import web
+import pytest
+
+from custom_components.nest_protect.pynest.client import NestClient
+
+
+@pytest.mark.enable_socket
+async def test_generate_token_url(aiohttp_client, loop):
+    """Tests for generate_token_url."""
+    app = web.Application()
+    client = await aiohttp_client(app)
+    nest_client = NestClient(client)
+    assert nest_client.generate_token_url() == (
+        "https://accounts.google.com/o/oauth2/auth/oauthchooseaccount"
+        "?access_type=offline&response_type=code"
+        "&scope=openid+profile+email+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fnest-account"
+        "&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob"
+        "&client_id=733249279899-1gpkq9duqmdp55a7e5lft1pr2smumdla.apps.googleusercontent.com"
+    )
+
+
+@pytest.mark.enable_socket
+async def test_get_access_token_success(aiohttp_client, loop):
+    """Test getting an access token."""
+
+    async def make_token_response(request):
+        return web.json_response({"access_token": "new-access-token"})
+
+    app = web.Application()
+    app.router.add_post("/token", make_token_response)
+    client = await aiohttp_client(app)
+
+    nest_client = NestClient(client)
+    with patch("custom_components.nest_protect.pynest.client.TOKEN_URL", "/token"):
+        access_token = await nest_client.get_access_token("refresh-token")
+        assert access_token == "new-access-token"
+
+
+@pytest.mark.enable_socket
+async def test_get_access_token_error(aiohttp_client, loop):
+    """Test failure while getting an access token."""
+
+    async def make_token_response(request):
+        return web.json_response({"error": "invalid_grant"})
+
+    app = web.Application()
+    app.router.add_post("/token", make_token_response)
+    client = await aiohttp_client(app)
+
+    nest_client = NestClient(client)
+    with patch(
+        "custom_components.nest_protect.pynest.client.TOKEN_URL", "/token"
+    ), pytest.raises(Exception, match="invalid_grant"):
+        await nest_client.get_access_token("refresh-token")
+
+
+@pytest.mark.enable_socket
+async def test_get_first_data_success(aiohttp_client, loop):
+    """Test getting initial data from the API."""
+
+    async def api_response(request):
+        json = await request.json()
+        request.app["request"].append((request.headers, json))
+        return web.json_response(
+            {
+                "updated_buckets": [
+                    {
+                        "object_key": "example-object-key",
+                    }
+                ]
+            }
+        )
+
+    app = web.Application()
+    app.router.add_post("/api/0.1/user/example-user/app_launch", api_response)
+    app["request"] = []
+    client = await aiohttp_client(app)
+
+    nest_client = NestClient(client)
+    with patch(
+        "custom_components.nest_protect.pynest.client.APP_LAUNCH_URL_FORMAT",
+        "/api/0.1/user/{user_id}/app_launch",
+    ):
+        result = await nest_client.get_first_data("access-token", "example-user")
+
+    assert len(app["request"]) == 1
+    (headers, json_request) = app["request"][0]
+    assert headers.get("Authorization") == "Basic access-token"
+    assert headers.get("X-nl-user-id") == "example-user"
+    assert json_request == {
+        "known_bucket_types": [
+            "buckets",
+            "structure",
+            "shared",
+            "topaz",
+            "device",
+            "rcs_settings",
+            "kryptonite",
+            "quartz",
+            "track",
+            "where",
+        ],
+        "known_bucket_versions": [],
+    }
+    assert result == {
+        "updated_buckets": [
+            {
+                "object_key": "example-object-key",
+            }
+        ]
+    }

--- a/tests/pynest/test_client.py
+++ b/tests/pynest/test_client.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 from aiohttp import web
 import pytest
 
-from custom_components.nest_protect.pynest.const import NEST_REQUEST
 from custom_components.nest_protect.pynest.client import NestClient
+from custom_components.nest_protect.pynest.const import NEST_REQUEST
 
 
 @pytest.mark.enable_socket

--- a/tests/pynest/test_client.py
+++ b/tests/pynest/test_client.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from aiohttp import web
 import pytest
 
+from custom_components.nest_protect.pynest.const import NEST_REQUEST
 from custom_components.nest_protect.pynest.client import NestClient
 
 
@@ -90,21 +91,7 @@ async def test_get_first_data_success(aiohttp_client, loop):
     (headers, json_request) = app["request"][0]
     assert headers.get("Authorization") == "Basic access-token"
     assert headers.get("X-nl-user-id") == "example-user"
-    assert json_request == {
-        "known_bucket_types": [
-            "buckets",
-            "structure",
-            "shared",
-            "topaz",
-            "device",
-            "rcs_settings",
-            "kryptonite",
-            "quartz",
-            "track",
-            "where",
-        ],
-        "known_bucket_versions": [],
-    }
+    assert json_request == NEST_REQUEST
     assert result == {
         "updated_buckets": [
             {


### PR DESCRIPTION
Add test coverage for pynest client library using aiohttp test library.  Add very simple tests that exercise a couple OAuth calls and one of the API calls.  Future improvements can include testing of error conditions, etc, but this is just to get an initial test harness in place.

This requires patching out the absolute API urls and changing them to be local urls so that the fake webserver can handle them, hence some of the changes to the API URL to use a constant.