### PR TITLE
Enable real-time updates for temperature sensors

### DIFF
--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -167,6 +167,13 @@ async def _async_subscribe_for_data(hass: HomeAssistant, entry: ConfigEntry, dat
                 for area in bucket_value["wheres"]:
                     entry_data.areas[area["where_id"]] = area["name"]
 
+            # Temperature Sensors
+            if key.startswith("kryptonite."):
+                kryptonite = Bucket(**bucket)
+                entry_data.devices[key] = kryptonite
+
+                async_dispatcher_send(hass, key, kryptonite)
+                
         # Update buckets with new data, to only receive new updates
         buckets = {d["object_key"]: d for d in result["objects"]}
         objects = [

--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -173,7 +173,7 @@ async def _async_subscribe_for_data(hass: HomeAssistant, entry: ConfigEntry, dat
                 entry_data.devices[key] = kryptonite
 
                 async_dispatcher_send(hass, key, kryptonite)
-                
+
         # Update buckets with new data, to only receive new updates
         buckets = {d["object_key"]: d for d in result["objects"]}
         objects = [


### PR DESCRIPTION
Adds temp to async_subscribe_for_data.

Works locally. I'm not a python expert. I just matched syntax with nest protect sensors, after noticing the temps were missing from this block.