### PR TITLE
Improve error logging during login

### DIFF
--- a/custom_components/nest_protect/pynest/client.py
+++ b/custom_components/nest_protect/pynest/client.py
@@ -194,7 +194,14 @@ class NestClient:
                     "2fa_state_changed"
                 )
 
-            self.nest_session = NestResponse(**nest_response)
+            try:
+                self.nest_session = NestResponse(**nest_response)
+            except Exception:
+                nest_response = await response.text()
+
+                raise PynestException(
+                    f"{response.status} error while authenticating - {nest_response}. Please create an issue on GitHub."
+                )
 
             return self.nest_session
 

--- a/custom_components/nest_protect/pynest/models.py
+++ b/custom_components/nest_protect/pynest/models.py
@@ -1,4 +1,5 @@
 """Models used by PyNest."""
+from __future__ import annotations
 
 from dataclasses import dataclass, field
 import datetime

--- a/custom_components/nest_protect/pynest/models.py
+++ b/custom_components/nest_protect/pynest/models.py
@@ -42,6 +42,7 @@ class NestResponse:
     weave: dict[str, str]
     user: str
     is_staff: bool
+    error: dict | None
     urls: NestUrls = field(default_factory=NestUrls)
     limits: NestLimits = field(default_factory=NestLimits)
 


### PR DESCRIPTION
It would be good to have better error logging during login. Eventually we can catch errors when they didn't migrate to a Google Account yet.