### PR TITLE
Need for minor version number (add .0)

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -6,7 +6,7 @@
         "select",
         "switch"
     ],
-    "homeassistant": "2022.11",
+    "homeassistant": "2022.11.0",
     "render_readme": "true",
     "iot_class": "Cloud Polling"
 }


### PR DESCRIPTION
Will allow install of v0.3.9 in Home Assistant 2022.11.0

Fixes https://github.com/iMicknl/ha-nest-protect/issues/112