### PR TITLE
Use async_forward_entry_setups function

### DIFF
--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -100,7 +100,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         client=client,
     )
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     # Subscribe for real-time updates
     # TODO cancel when closing HA / unloading entry


### PR DESCRIPTION
- Utilize `async_forward_entry_setups` instead of `async_setup_platforms`

Starting with Home Assistant 2023.3, any integration using the old function will fail to start.