### PR TITLE
Update sensor.py to treat Nest temperature sensor readings as measurements

### DIFF
--- a/custom_components/nest_protect/sensor.py
+++ b/custom_components/nest_protect/sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
+    SensorStateClass,
 )
 from homeassistant.const import PERCENTAGE, TEMP_CELSIUS
 from homeassistant.helpers.entity import EntityCategory
@@ -49,6 +50,7 @@ SENSOR_DESCRIPTIONS: list[SensorEntityDescription] = [
         value_fn=lambda state: round(state, 2),
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=TEMP_CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     # TODO Add Color Status (gray, green, yellow, red)
     # TODO Smoke Status (OK, Warning, Emergency)


### PR DESCRIPTION
Added sensor state class of "measurement" to the Nest Protect temperature sensor definition, so that HA recognizes and collects min/mean/max statistical information for these sensors. Replacement pull request for iMicknl/ha-nest-protect#244 after re-syncing my fork. 😁 