### PR TITLE
Add battery-level calculation

### DIFF
--- a/custom_components/nest_protect/sensor.py
+++ b/custom_components/nest_protect/sensor.py
@@ -1,6 +1,7 @@
 """Sensor platform for Nest Protect."""
 from __future__ import annotations
 
+import math
 from collections.abc import Callable
 from dataclasses import dataclass
 import datetime
@@ -31,7 +32,7 @@ SENSOR_DESCRIPTIONS: list[SensorEntityDescription] = [
     NestProtectSensorDescription(
         key="battery_level",
         name="Battery Level",
-        value_fn=lambda state: state if state <= 100 else None,
+        value_fn=lambda state: math.floor((state/54) + 0.5) if state <= 5400 else None,
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
         entity_category=EntityCategory.DIAGNOSTIC,


### PR DESCRIPTION
The battery-level value function in the Nest Protect sensor has been updated to convert the state value to a percentage.

Both battery and wired Protect require Energizer Ultimate Lithium AA (L91) batteries.
Protect (Battery) requires 6 AA batteries. Protect (Wired) requires 3 AA as backup batteries.
Wired Protects will use backup batteries if there’s a power outage.

I assume:
* A set is three batteries placed in series.
* The battery protect places two sets in parallel, while the wired has only one set.
* state is the battery level in mV.

The normal open circuit voltage for an L91 ranges from 1.75-1.8V.
This makes the maximum voltage of 1 set or 2 sets in parallel: `3 * 1.8 = 5.4V = 5400mV`

```
Battery Percentage = state / max * 100
Battery Percentage = state / 5400 * 100 = state / 54
Rounded Percentage = floor((Battery Percentage / 54) + 0.5)
```

Closes #67
