### PR TITLE
Add battery-level calculation for devices that report mV

### DIFF
--- a/custom_components/nest_protect/sensor.py
+++ b/custom_components/nest_protect/sensor.py
@@ -21,6 +21,8 @@ from .entity import NestDescriptiveEntity
 
 
 def battery_calc(state):
+    """Calculate battery level if device is reporting in mV."""
+
     if state <= 100:
         result = state
     elif 4200 < state <= 5260:

--- a/custom_components/nest_protect/sensor.py
+++ b/custom_components/nest_protect/sensor.py
@@ -47,11 +47,13 @@ def battery_calc(state):
 
     return result
 
+
 @dataclass
 class NestProtectSensorDescription(SensorEntityDescription):
     """Class to describe an Nest Protect sensor."""
 
     value_fn: Callable[[Any], StateType] | None = None
+
 
 SENSOR_DESCRIPTIONS: list[SensorEntityDescription] = [
     NestProtectSensorDescription(

--- a/custom_components/nest_protect/sensor.py
+++ b/custom_components/nest_protect/sensor.py
@@ -25,8 +25,8 @@ def battery_calc(state):
 
     if state <= 100:
         result = state
-    elif 4200 < state <= 5260:
-        if 4950 < state <= 5260:
+    elif 3000 < state <= 6000:
+        if 4950 < state <= 6000:
             slope = 0.001816609
             yint = -8.548096886
         elif 4800 < state <= 4950:
@@ -39,7 +39,7 @@ def battery_calc(state):
             slope = 0.000434641
             yint = -1.825490196
 
-        result = round(((slope * state) + yint) * 100)
+        result = max(0, min(100, round(((slope * state) + yint) * 100)))
     else:
         result = None
 


### PR DESCRIPTION
This calculation is based on the L91 battery's datasheet that shows a distinct set of slopes to measure the approximate percentage of battery life left in devices that report 4000+ as the state.  This number is the mV of the 6 batteries in the battery powered Nest Protect and the 3 batteries as backup in the wired version.  I have tested this on 11 battery and 3 wired, and the results are pretty accurate based on the info I can see and the use I know each sensor gets.  Temperature sensors (for the thermostat) simply pass through as they did previously because it was already returning percentage for those.  In my tests, my batteries range from 100% to 27% with everything in between.  I also had one need replacement and it was sub 10% with the "battery low" state true as reported by the API.

Closes #67