### PR TITLE
Avoid some errors in the log

### DIFF
--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -160,7 +160,9 @@ async def _async_subscribe_for_data(hass: HomeAssistant, entry: ConfigEntry, dat
         if not entry_data.client.auth or entry_data.client.auth.is_expired():
             LOGGER.debug("Subscriber: retrieving new Google access token")
             auth = await entry_data.client.get_access_token()
-            entry_data.client.nest_session = await entry_data.client.authenticate(auth)
+            entry_data.client.nest_session = await entry_data.client.authenticate(
+                auth.access_token
+            )
 
         # Subscribe to Google Nest subscribe endpoint
         result = await entry_data.client.subscribe_for_data(


### PR DESCRIPTION
It seems there is a minor bug when refreshing the access_token from nestauthproxyservice.
As input to the authenticate method it gives the entire auth object rather than the access_token within it. Thus, the call to nestauthproxyservice will fail.

It seems to overcome the issue by trying again later, apparently with correct input.
This PR just avoids some errors in the log. Most likely the ones mentioned in #267.
