### PR TITLE
Fix battery level sensor for Nest Temperature Sensors

### DIFF
--- a/custom_components/nest_protect/sensor.py
+++ b/custom_components/nest_protect/sensor.py
@@ -116,7 +116,9 @@ async def async_setup_entry(hass, entry, async_add_devices):
     for device in data.devices.values():
 
         SUPPORTED_KEYS: dict[str, NestProtectSensorDescription] = {
-            description.key: description for description in SENSOR_DESCRIPTIONS if (not description.bucket_type or device.type == description.bucket_type)
+            description.key: description
+            for description in SENSOR_DESCRIPTIONS
+            if (not description.bucket_type or device.type == description.bucket_type)
         }
             
         for key in device.value:

--- a/custom_components/nest_protect/sensor.py
+++ b/custom_components/nest_protect/sensor.py
@@ -120,7 +120,7 @@ async def async_setup_entry(hass, entry, async_add_devices):
             for description in SENSOR_DESCRIPTIONS
             if (not description.bucket_type or device.type == description.bucket_type)
         }
-            
+
         for key in device.value:
             if description := SUPPORTED_KEYS.get(key):
                 entities.append(

--- a/custom_components/nest_protect/sensor.py
+++ b/custom_components/nest_protect/sensor.py
@@ -113,16 +113,14 @@ async def async_setup_entry(hass, entry, async_add_devices):
     data: HomeAssistantNestProtectData = hass.data[DOMAIN][entry.entry_id]
     entities: list[NestProtectSensor] = []
 
-    SUPPORTED_KEYS: dict[str, NestProtectSensorDescription] = {
-        description.key: description for description in SENSOR_DESCRIPTIONS
-    }
-
     for device in data.devices.values():
+
+        SUPPORTED_KEYS: dict[str, NestProtectSensorDescription] = {
+            description.key: description for description in SENSOR_DESCRIPTIONS if (not description.bucket_type or device.type == description.bucket_type)
+        }
+            
         for key in device.value:
             if description := SUPPORTED_KEYS.get(key):
-                if description.bucket_type and device.type != description.bucket_type:
-                    continue
-
                 entities.append(
                     NestProtectSensor(device, description, data.areas, data.client)
                 )


### PR DESCRIPTION
This was regressed as part of commit https://github.com/iMicknl/ha-nest-protect/commit/54c98d3e40a152bf8c7299234adcbaac1f568793

SUPPORTED_KEYS is a dictionary using sensor description key as the "key". Prior to this fix, SUPPORTED_KEYS was always picking up the Nest Protect sensor description and completely ignoring the temperature sensor one.