### PR TITLE
Fix broken code block in bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -77,10 +77,10 @@ body:
       description: Enable [debug logging](https://github.com/iMicknl/ha-nest-protect#enable-debug-logging) and paste your full log here, if you have errors.
       value: |
         <details><summary>Logs</summary>
+        
         ```
         Copy/paste any log here, between the starting and ending backticks (`)
         ```
-
         </details>
 
   - type: textarea


### PR DESCRIPTION
before this PR:
<details><summary>Logs</summary>
```
code goes here
```

</details>

after this PR:
<details><summary>Logs</summary>

```
code goes here
```
</details>