### PR TITLE
deprecation fixes

### DIFF
--- a/custom_components/nest_protect/sensor.py
+++ b/custom_components/nest_protect/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.const import PERCENTAGE, TEMP_CELSIUS
+from homeassistant.const import PERCENTAGE, UnitOfTemperature
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.typing import StateType
 
@@ -99,7 +99,7 @@ SENSOR_DESCRIPTIONS: list[NestProtectSensorDescription] = [
         key="current_temperature",
         value_fn=lambda state: round(state, 2),
         device_class=SensorDeviceClass.TEMPERATURE,
-        native_unit_of_measurement=TEMP_CELSIUS,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     ),
     # TODO Add Color Status (gray, green, yellow, red)
     # TODO Smoke Status (OK, Warning, Emergency)
@@ -144,3 +144,4 @@ class NestProtectSensor(NestDescriptiveEntity, SensorEntity):
             return self.entity_description.value_fn(state)
 
         return state
+    

--- a/custom_components/nest_protect/sensor.py
+++ b/custom_components/nest_protect/sensor.py
@@ -144,4 +144,3 @@ class NestProtectSensor(NestDescriptiveEntity, SensorEntity):
             return self.entity_description.value_fn(state)
 
         return state
-    

--- a/tests/pynest/test_client.py
+++ b/tests/pynest/test_client.py
@@ -10,7 +10,7 @@ from custom_components.nest_protect.pynest.const import NEST_REQUEST
 
 @pytest.mark.enable_socket
 async def test_get_access_token_from_cookies_success(
-    socket_enabled, aiohttp_client, loop
+    socket_enabled, aiohttp_client, event_loop
 ):
     """Test getting an access token."""
 
@@ -38,7 +38,7 @@ async def test_get_access_token_from_cookies_success(
 
 @pytest.mark.enable_socket
 async def test_get_access_token_from_cookies_error(
-    socket_enabled, aiohttp_client, loop
+    socket_enabled, aiohttp_client, event_loop
 ):
     """Test failure while getting an access token."""
 
@@ -57,7 +57,7 @@ async def test_get_access_token_from_cookies_error(
 
 
 @pytest.mark.enable_socket
-async def test_get_first_data_success(socket_enabled, aiohttp_client, loop):
+async def test_get_first_data_success(socket_enabled, aiohttp_client, event_loop):
     """Test getting initial data from the API."""
 
     async def api_response(request):


### PR DESCRIPTION
TEMP_CELSIUS is deprecated and due to be removed next year in favor of UnitOfTemperature.CELSIUS.

loop is deprecated in favor of event_loop which causes a warning when running pytest. unrelated, but figured it should be fixed.

Closes issue https://github.com/iMicknl/ha-nest-protect/issues/290
Replaces PR https://github.com/iMicknl/ha-nest-protect/pull/293