### PR TITLE
import StrEnum from enum

### DIFF
--- a/custom_components/nest_protect/entity.py
+++ b/custom_components/nest_protect/entity.py
@@ -1,7 +1,7 @@
 """Entity class for Nest Protect."""
 from __future__ import annotations
 
-from enum import unique, StrEnum
+from enum import StrEnum, unique
 
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr

--- a/custom_components/nest_protect/entity.py
+++ b/custom_components/nest_protect/entity.py
@@ -1,9 +1,8 @@
 """Entity class for Nest Protect."""
 from __future__ import annotations
 
-from enum import unique
+from enum import unique, StrEnum
 
-from homeassistant.backports.enum import StrEnum
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_connect


### PR DESCRIPTION
The StrEnum backport has been deprecated ([see related developer blog post](https://developers.home-assistant.io/blog/2024/04/08/deprecated-backports-and-typing-aliases)). This PR addresses the issue by directly importing StrEnum from enum.

This PR fixes #327 