### PR TITLE
Update constant to use UnitOfTemperature

### DIFF
--- a/custom_components/nest_protect/sensor.py
+++ b/custom_components/nest_protect/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.const import PERCENTAGE, TEMP_CELSIUS
+from homeassistant.const import PERCENTAGE, UnitOfTemperature
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.typing import StateType
 
@@ -48,7 +48,7 @@ SENSOR_DESCRIPTIONS: list[SensorEntityDescription] = [
         key="current_temperature",
         value_fn=lambda state: round(state, 2),
         device_class=SensorDeviceClass.TEMPERATURE,
-        native_unit_of_measurement=TEMP_CELSIUS,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     ),
     # TODO Add Color Status (gray, green, yellow, red)
     # TODO Smoke Status (OK, Warning, Emergency)


### PR DESCRIPTION
PR to resolve the following issue raised in the logs.

`TEMP_CELSIUS was used from nest_protect, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead, please report it to the author of the 'nest_protect' custom integration`