### PR TITLE
Fix Python Tests Dependency Installation Error on Beta

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,5 +2,5 @@
 
 pytest==7.4.4
 pytest-socket==0.7.0
-pytest-homeassistant-custom-component==0.13.135 # 2024.6.3
+pytest-homeassistant-custom-component
 pytest-timeout==2.3.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,5 +2,5 @@
 
 pytest==7.4.3
 pytest-socket==0.6.0
-pytest-homeassistant-custom-component==0.13.85 # 2023.12.3
+pytest-homeassistant-custom-component==0.13.135 # 2024.6.3
 pytest-timeout==2.1.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,6 @@
 -r requirements_dev.txt
 
-pytest==7.4.3
+pytest==7.4.4
 pytest-socket==0.7.0
 pytest-homeassistant-custom-component==0.13.135 # 2024.6.3
 pytest-timeout==2.3.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,6 @@
 -r requirements_dev.txt
 
 pytest==7.4.3
-pytest-socket==0.6.0
+pytest-socket==0.7.0
 pytest-homeassistant-custom-component==0.13.135 # 2024.6.3
 pytest-timeout==2.1.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,4 +3,4 @@
 pytest==7.4.3
 pytest-socket==0.7.0
 pytest-homeassistant-custom-component==0.13.135 # 2024.6.3
-pytest-timeout==2.1.0
+pytest-timeout==2.3.1


### PR DESCRIPTION
You had bumped the version number of homeassistant in requirements_dev but not the version number of pytest-homeassistant-custom-component in requirements_test leading to a dependency conflict.