### PR TITLE
Trying to fix Errors in _async_subscribe_for_data #347 

### DIFF
--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -206,10 +206,19 @@ async def _async_subscribe_for_data(
         LOGGER.debug(buckets)
 
         objects = [
-            dict(b, **buckets.get(b.object_key, {})) for b in [data.updated_buckets]
+            dict(vars(b), **buckets.get(b.object_key, {})) for b in data.updated_buckets
         ]
 
-        data.updated_buckets = objects
+        data.updated_buckets = [
+            Bucket(
+                object_key=bucket["object_key"],
+                object_revision=bucket["object_revision"],
+                object_timestamp=bucket["object_timestamp"],
+                value=bucket["value"],
+                type=bucket["type"]
+        )
+        for bucket in objects
+        ]
 
         _register_subscribe_task(hass, entry, data)
     except ServerDisconnectedError:

--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -216,8 +216,8 @@ async def _async_subscribe_for_data(
                 object_timestamp=bucket["object_timestamp"],
                 value=bucket["value"],
                 type=bucket["type"]
-        )
-        for bucket in objects
+            )
+            for bucket in objects
         ]
 
         _register_subscribe_task(hass, entry, data)

--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -215,7 +215,7 @@ async def _async_subscribe_for_data(
                 object_revision=bucket["object_revision"],
                 object_timestamp=bucket["object_timestamp"],
                 value=bucket["value"],
-                type=bucket["type"]
+                type=bucket["type"],
             )
             for bucket in objects
         ]

--- a/custom_components/nest_protect/pynest/models.py
+++ b/custom_components/nest_protect/pynest/models.py
@@ -85,7 +85,12 @@ class Bucket:
         # if self.type == BucketType.TOPAZ:
         #     self.value = TopazBucketValue(**self.value)
         if self.type == BucketType.WHERE:
-            self.value = WhereBucketValue(**self.value)
+            if isinstance(self.value, WhereBucketValue):
+                # It's already the correct type, no need to reinitialize
+                pass
+            else:
+                # Convert dictionary to WhereBucketValue instance
+                self.value = WhereBucketValue(**self.value)
 
 
 @dataclass


### PR DESCRIPTION
I have managed to squash all the errors popping up from that _async_subscribe_for_data, but I am not sure that the main logic is correct in the code. If after this fix, it still generates high traffic to the Google servers, then the whole logic of subscribing is flawed somewhere.

To be honest, I don't understand what is meant to be achieved with this part of the code. It might be re-subscribing after each message received from Google, and that causes a lot of traffic. I cannot test the traffic issue, because I have only battery powered Nest protects.

It should fix #338 as well, as they are duplicates.

Fixes #338