### PR TITLE
Fixing PynestException: 200 error while subscribing - #345

### DIFF
--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -30,6 +30,7 @@ from .pynest.exceptions import (
     NestServiceException,
     NotAuthenticatedException,
     PynestException,
+    EmptyResponseException,
 )
 from .pynest.models import Bucket, FirstDataAPIResponse, TopazBucket, WhereBucketValue
 
@@ -221,6 +222,10 @@ async def _async_subscribe_for_data(
 
     except ClientConnectorError:
         LOGGER.debug("Subscriber: cannot connect to host.")
+        _register_subscribe_task(hass, entry, data)
+
+    except EmptyResponseException:
+        LOGGER.debug("Subscriber: Nest Service sent empty response.")
         _register_subscribe_task(hass, entry, data)
 
     except NotAuthenticatedException:

--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -27,10 +27,10 @@ from .pynest.const import NEST_ENVIRONMENTS
 from .pynest.enums import BucketType, Environment
 from .pynest.exceptions import (
     BadCredentialsException,
+    EmptyResponseException,
     NestServiceException,
     NotAuthenticatedException,
     PynestException,
-    EmptyResponseException,
 )
 from .pynest.models import Bucket, FirstDataAPIResponse, TopazBucket, WhereBucketValue
 

--- a/custom_components/nest_protect/pynest/client.py
+++ b/custom_components/nest_protect/pynest/client.py
@@ -21,10 +21,10 @@ from .const import (
 from .exceptions import (
     BadCredentialsException,
     BadGatewayException,
+    EmptyResponseException,
     GatewayTimeoutException,
     NotAuthenticatedException,
     PynestException,
-    EmptyResponseException,
 )
 from .models import (
     Bucket,
@@ -316,7 +316,7 @@ class NestClient:
 
             if response.status == 200 and response.content_type == "text/plain":
                 raise EmptyResponseException(await response.text())
-                
+
             try:
                 result = await response.json()
             except ContentTypeError as error:

--- a/custom_components/nest_protect/pynest/client.py
+++ b/custom_components/nest_protect/pynest/client.py
@@ -24,6 +24,7 @@ from .exceptions import (
     GatewayTimeoutException,
     NotAuthenticatedException,
     PynestException,
+    EmptyResponseException,
 )
 from .models import (
     Bucket,
@@ -313,6 +314,9 @@ class NestClient:
             if response.status == 502:
                 raise BadGatewayException(await response.text())
 
+            if response.status == 200 and response.content_type == "text/plain":
+                raise EmptyResponseException(await response.text())
+                
             try:
                 result = await response.json()
             except ContentTypeError as error:

--- a/custom_components/nest_protect/pynest/exceptions.py
+++ b/custom_components/nest_protect/pynest/exceptions.py
@@ -36,7 +36,8 @@ class BadGatewayException(NestServiceException):
 
     pass
 
+
 class EmptyResponseException(NestServiceException):
-    """Raised when server returns Status 200 (OK), but empty repsonse."""
+    """Raised when server returns Status 200 (OK), but empty response."""
 
     pass

--- a/custom_components/nest_protect/pynest/exceptions.py
+++ b/custom_components/nest_protect/pynest/exceptions.py
@@ -35,3 +35,8 @@ class BadGatewayException(NestServiceException):
     """Raised when server returns Bad Gateway."""
 
     pass
+
+class EmptyResponseException(NestServiceException):
+    """Raised when server returns Status 200 (OK), but empty repsonse."""
+
+    pass


### PR DESCRIPTION
This PR should fix #345 and handle the Nest Service response 200 with plain/text content_type (without any).

But to be honest, there might be some other underlying issue, as I would expect if the response is 200, then there would be normal json content. For now it retries the `_register_subscribe_task(hass, entry, data)`. But it could be better to issue a `close()` or `release()` and then retry. I don't have resources to investigate it further, as the response comes sporadically. 

Fixes #345