### PR TITLE
Reduce timeout for subscription sessions to avoid lost connections

### DIFF
--- a/custom_components/nest_protect/manifest.json
+++ b/custom_components/nest_protect/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/imicknl/ha-nest-protect/issues",
   "requirements": [],
-  "version": "0.4.0"
+  "version": "0.4.1b1"
 }

--- a/custom_components/nest_protect/pynest/client.py
+++ b/custom_components/nest_protect/pynest/client.py
@@ -275,7 +275,7 @@ class NestClient:
         updated_buckets: dict,
     ) -> Any:
         """Subscribe for data."""
-        timeout = 3600 * 24
+        timeout = 600
 
         objects = []
         for bucket in updated_buckets:


### PR DESCRIPTION
The timeout has been reduced from 3600 x 24 to 600, to operate as a heart beat. The total timeout was too long to handle well lost internet connections. With the reduced timeout, if the HA instance is disconnected from the internet and loose the callback connection, which is not caught by the aiohttp as an exception, the integration will re-initiate a connection as the timeout reached. 

The limit set to 600, as on previous versions where the integration was failing, it was reconnecting every 300 seconds. It is the double of that for not introducing excessive load on any server.