### PR TITLE
Fixing TypeError: 'WhereBucketValue' object is not subscriptable #401

### DIFF
--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -190,8 +190,8 @@ async def _async_subscribe_for_data(
             if key.startswith("where."):
                 bucket_value = Bucket(**bucket).value
 
-                for area in bucket_value["wheres"]:
-                    entry_data.areas[area["where_id"]] = area["name"]
+                for area in bucket_value.wheres:
+                    entry_data.areas[area.where_id] = area.name
 
             # Temperature Sensors
             if key.startswith("kryptonite."):


### PR DESCRIPTION
This should handle the error, as it is already handled a few lines above the same way.

Should fix #401 

(To reproduce the error, change the name of a Protect to a custom one.)