### PR TITLE
Re-auth prompt on BadCredentialsException

### DIFF
--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -244,6 +244,10 @@ async def _async_subscribe_for_data(
         await entry_data.client.authenticate(entry_data.client.auth.access_token)
         _register_subscribe_task(hass, entry, data)
 
+    except BadCredentialsException as exception:
+        LOGGER.debug("Need to re-authenticate the integration")
+        raise ConfigEntryAuthFailed from exception
+
     except NestServiceException:
         LOGGER.debug("Subscriber: Nest Service error. Updates paused for 2 minutes.")
 


### PR DESCRIPTION
This should fix Nest Protect integration for Home Assistant looses authentication after home assistant restarts #341, where the integration really has to be-authenticate.