### PR TITLE
fix(strings.json): 🔧 update integration dialog github url (#447)

### DIFF
--- a/custom_components/nest_protect/strings.json
+++ b/custom_components/nest_protect/strings.json
@@ -8,7 +8,7 @@
         }
       },
       "account_link": {
-        "description": "Unfortunately, Google does not provide an official API for this integration. To get it working, you will need to manually retrieve your issue_token and cookies by following the instructions in the integration README (https://github.com/iMicknl/ha-nest-protect/tree/#retrieving-issue_token-and-cookies). Please paste them below.",
+        "description": "Unfortunately, Google does not provide an official API for this integration. To get it working, you will need to manually retrieve your issue_token and cookies by following the instructions in the integration README (https://github.com/iMicknl/ha-nest-protect/#retrieving-issue_token-and-cookies). Please paste them below.",
         "data": {
           "issue_token": "[%key:common::config_flow::data::issue_token%]",
           "cookies": "[%key:common::config_flow::data::cookies%]"

--- a/custom_components/nest_protect/translations/en.json
+++ b/custom_components/nest_protect/translations/en.json
@@ -16,7 +16,7 @@
         }
       },
       "account_link": {
-        "description": "Unfortunately, Google does not provide an official API for this integration. To get it working, you will need to manually retrieve your issue_token and cookies by following the instructions in the integration README (https://github.com/iMicknl/ha-nest-protect/tree/#retrieving-issue_token-and-cookies). Please paste them below.",
+        "description": "Unfortunately, Google does not provide an official API for this integration. To get it working, you will need to manually retrieve your issue_token and cookies by following the instructions in the integration README (https://github.com/iMicknl/ha-nest-protect/#retrieving-issue_token-and-cookies). Please paste them below.",
         "data": {
           "issue_token": "Issue_token",
           "cookies": "Cookies"

--- a/custom_components/nest_protect/translations_legacy/de.json
+++ b/custom_components/nest_protect/translations_legacy/de.json
@@ -15,7 +15,7 @@
         }
       },
       "account_link": {
-        "description": "Bitte holen Sie sich Ihr Issue_Token und Ihre Cookies gemäß den Anweisungen in der [Integrations-README](https://github.com/iMicknl/ha-nest-protect/tree/#retrieving-issue_token-and-cookies) und fügen Sie sie unten ein.",
+        "description": "Bitte holen Sie sich Ihr Issue_Token und Ihre Cookies gemäß den Anweisungen in der [Integrations-README](https://github.com/iMicknl/ha-nest-protect/#retrieving-issue_token-and-cookies) und fügen Sie sie unten ein.",
         "data": {
           "issue_token": "issue_token",
           "cookies": "cookies"

--- a/custom_components/nest_protect/translations_legacy/en.json
+++ b/custom_components/nest_protect/translations_legacy/en.json
@@ -15,7 +15,7 @@
         }
       },
       "account_link": {
-        "description": "Please retrieve your issue_token and cookies manually, following the instructions in the [integration README](https://github.com/iMicknl/ha-nest-protect/tree/#retrieving-issue_token-and-cookies) and paste them below.",
+        "description": "Please retrieve your issue_token and cookies manually, following the instructions in the [integration README](https://github.com/iMicknl/ha-nest-protect/#retrieving-issue_token-and-cookies) and paste them below.",
         "data": {
           "issue_token": "issue_token",
           "cookies": "cookies"

--- a/custom_components/nest_protect/translations_legacy/fr.json
+++ b/custom_components/nest_protect/translations_legacy/fr.json
@@ -15,7 +15,7 @@
         }
       },
       "account_link": {
-        "description": "Veuillez récupérer votre issue_token et vos cookies en suivant les instructions du fichier [README](https://github.com/iMicknl/ha-nest-protect/tree/#retrieving-issue_token-and-cookies) d'intégration et collez-les ci-dessous.",
+        "description": "Veuillez récupérer votre issue_token et vos cookies en suivant les instructions du fichier [README](https://github.com/iMicknl/ha-nest-protect/#retrieving-issue_token-and-cookies) d'intégration et collez-les ci-dessous.",
         "data": {
           "issue_token": "issue_token",
           "cookies": "cookies"

--- a/custom_components/nest_protect/translations_legacy/nl.json
+++ b/custom_components/nest_protect/translations_legacy/nl.json
@@ -15,7 +15,7 @@
         }
       },
       "account_link": {
-        "description": "Verkrijg uw issue_token en cookies handmatig, volgens de instructies in de [README](https://github.com/iMicknl/ha-nest-protect/tree/#retrieving-issue_token-and-cookies) en plak ze hieronder.",
+        "description": "Verkrijg uw issue_token en cookies handmatig, volgens de instructies in de [README](https://github.com/iMicknl/ha-nest-protect/#retrieving-issue_token-and-cookies) en plak ze hieronder.",
         "data": {
           "issue_token": "issue_token",
           "cookies": "cookies"

--- a/custom_components/nest_protect/translations_legacy/pt-BR.json
+++ b/custom_components/nest_protect/translations_legacy/pt-BR.json
@@ -15,7 +15,7 @@
         }
       },
       "account_link": {
-        "description": "Obtenha seu issue_token e cookies seguindo as instruções no [LEIA-ME](https://github.com/iMicknl/ha-nest-protect/tree/#retrieving-issue_token-and-cookies) de integração e cole-os abaixo.",
+        "description": "Obtenha seu issue_token e cookies seguindo as instruções no [LEIA-ME](https://github.com/iMicknl/ha-nest-protect/#retrieving-issue_token-and-cookies) de integração e cole-os abaixo.",
         "data": {
           "issue_token": "issue_token",
           "cookies": "cookies"


### PR DESCRIPTION
## 📝 Commits

- ```
  fix(strings.json): 🔧 update integration dialog github url (#447)

  Fixed incorrect github README url path in home assistant integration setup dialog.

  Fixes #447
  ```

## 🔀 Changes

- Fixed README URL in `strings.json` and in corresponding translation json files:

  ```diff
  - https://github.com/iMicknl/ha-nest-protect/tree/#retrieving-issue_token-and-cookies
  + https://github.com/iMicknl/ha-nest-protect/#retrieving-issue_token-and-cookies
  ```

- 7 files updated:
  - `custom_components/nest_protect/strings.json`
  - `custom_components/nest_protect/translations/en.json`
  - `custom_components/nest_protect/translations_legacy/de.json`
  - `custom_components/nest_protect/translations_legacy/en.json`
  - `custom_components/nest_protect/translations_legacy/fr.json`
  - `custom_components/nest_protect/translations_legacy/nl.json`
  - `custom_components/nest_protect/translations_legacy/pt-BR.json`

Fixes #447