### PR TITLE
Fix TypeError: 'WhereBucketValue' object is not subscriptable

### DIFF
--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -213,8 +213,8 @@ async def _async_subscribe_for_data(
             if key.startswith("where."):
                 bucket_value = Bucket(**bucket).value
 
-                for area in bucket_value["wheres"]:
-                    entry_data.areas[area["where_id"]] = area["name"]
+                for area in bucket_value.wheres:
+                    entry_data.areas[area.where_id] = area.name
 
             # Temperature Sensors
             if key.startswith("kryptonite."):


### PR DESCRIPTION
## Summary

- Access `WhereBucketValue` attributes via dot notation instead of dict subscript notation, fixing a `TypeError` when custom area names are used
- Consistent with how other bucket values are accessed in the same function

Fixes #401

Based on the fix originally proposed in #429 by @GSzabados.

## Test plan

- [ ] Rename a Nest Protect device to a custom name and verify no `TypeError` occurs
- [ ] Verify areas are still correctly populated after subscription updates