### PR TITLE
Add automatic version bump on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Retrieve version from tag name
+        id: retrieve-version
+        run: |
+          tag="${{ github.event.release.tag_name }}"
+          version_number="${tag#v}"
+          echo "version: $version_number"
+          echo "version=$version_number" >> "$GITHUB_OUTPUT"
+
+      - name: Bump version in manifest.json
+        run: |
+          VERSION=${{ steps.retrieve-version.outputs.version }}
+          jq --arg v "$VERSION" '.version = $v' custom_components/nest_protect/manifest.json > tmp.json
+          mv tmp.json custom_components/nest_protect/manifest.json
+
+      - name: Commit and push changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+
+          git add custom_components/nest_protect/manifest.json
+          git commit -m "Bump version to ${{ steps.retrieve-version.outputs.version }}"
+
+          git tag -f -a ${{ github.event.release.tag_name }} -m "Release ${{ steps.retrieve-version.outputs.version }}"
+          git push origin HEAD:main
+          git push origin -f ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically updates the version in `manifest.json` when a release is published
- Extracts the version from the release tag (e.g. `v0.5.0` → `0.5.0`), updates the manifest, commits to main, and re-tags
- No more manual version bumps needed — just publish the release draft from release-drafter

## How it works
1. Release Drafter creates a draft release with the next version tag
2. Maintainer publishes the release
3. This workflow triggers, bumps `manifest.json`, commits, and force-updates the tag

Based on the same pattern used in [python-overkiz-api](https://github.com/iMicknl/python-overkiz-api).