### PR TITLE
Handle transient network errors gracefully

### DIFF
--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -6,7 +6,12 @@ import asyncio
 import contextlib
 from dataclasses import dataclass
 
-from aiohttp import ClientConnectorError, ClientError, ServerDisconnectedError
+from aiohttp import (
+    ClientConnectorError,
+    ClientError,
+    ClientOSError,
+    ServerDisconnectedError,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
@@ -265,6 +270,10 @@ async def _async_subscribe_for_data(
 
     except ClientConnectorError:
         LOGGER.debug("Subscriber: cannot connect to host.")
+        _register_subscribe_task(hass, entry, data)
+
+    except ClientOSError:
+        LOGGER.debug("Subscriber: connection reset.")
         _register_subscribe_task(hass, entry, data)
 
     except EmptyResponseException:

--- a/custom_components/nest_protect/pynest/client.py
+++ b/custom_components/nest_protect/pynest/client.py
@@ -23,6 +23,7 @@ from .exceptions import (
     BadGatewayException,
     EmptyResponseException,
     GatewayTimeoutException,
+    NestServiceException,
     NotAuthenticatedException,
     PynestException,
 )
@@ -360,7 +361,7 @@ class NestClient:
             except ContentTypeError as error:
                 result = await response.text()
 
-                raise PynestException(
+                raise NestServiceException(
                     f"{response.status} error while subscribing - {result}"
                 ) from error
 


### PR DESCRIPTION
## Summary

- Treat `ContentTypeError` (400 with text/plain response) as a `NestServiceException` instead of `PynestException`, so it retries quietly instead of logging "Please create an issue on GitHub"
- Add `ClientOSError` (connection resets) as a handled transient error alongside `ServerDisconnectedError` and `ClientConnectorError`

Fixes #437, fixes #446, fixes #451

## Test plan

- [ ] Verify integration starts and subscribes normally
- [ ] Simulate a 400 text/plain response from Nest subscribe endpoint and confirm debug-level log + retry (no error spam)
- [ ] Simulate a connection reset during auth and confirm debug-level log + immediate retry