### PR TITLE
Clean cookies in config flow to prevent auth failures

### DIFF
--- a/custom_components/nest_protect/config_flow.py
+++ b/custom_components/nest_protect/config_flow.py
@@ -34,6 +34,25 @@ DESCRIPTION_PLACEHOLDERS = {
     "extension_download_url": "https://github.com/iMicknl/ha-nest-protect/releases/latest/download/nest-auth-helper.zip",
 }
 
+REQUIRED_COOKIE_NAMES: set[str] = {
+    "NID",
+    "__Secure-3PSID",
+    "__Secure-3PAPISID",
+    "__Host-3PLSID",
+    "__Secure-3PSIDCC",
+    "APISID",
+    "SAPISID",
+    "HSID",
+    "SSID",
+    "SID",
+    "__Secure-1PSID",
+    "__Secure-1PAPISID",
+    "__Host-1PLSID",
+    "__Secure-1PSIDCC",
+    "SIDCC",
+    "LSID",
+}
+
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for Nest Protect."""
@@ -42,6 +61,28 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     _config_entry: ConfigEntry | None = None
     _default_account_type: Environment = Environment.PRODUCTION
+
+    @staticmethod
+    def _clean_cookies(cookies: str) -> str:
+        """Clean cookies by keeping only the ones needed for authentication.
+
+        Users often copy extra cookies from non-incognito sessions which can
+        cause authentication failures. This strips unnecessary cookies while
+        preserving the required Google auth cookies.
+        """
+        cleaned_pairs = []
+        for raw_pair in cookies.split(";"):
+            stripped = raw_pair.strip()
+            if not stripped or "=" not in stripped:
+                continue
+            name = stripped.split("=", 1)[0].strip()
+            if name in REQUIRED_COOKIE_NAMES:
+                cleaned_pairs.append(stripped)
+
+        if cleaned_pairs:
+            return "; ".join(cleaned_pairs)
+        # If no known cookies matched, return original to let validation catch it
+        return cookies
 
     @staticmethod
     def _validate_issue_token(issue_token: str) -> bool:
@@ -168,8 +209,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     base64.b64decode(user_input[CONF_AUTH_CODE]).decode()
                 )
                 issue_token = decoded["issue_token"]
-                cookies = decoded["cookies"]
-            except ValueError, KeyError, json.JSONDecodeError:
+                cookies = self._clean_cookies(decoded["cookies"])
+            except (ValueError, KeyError, json.JSONDecodeError):
                 errors[CONF_AUTH_CODE] = "invalid_code"
 
             if not errors and (
@@ -188,7 +229,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     [issue_token, cookies, email] = await self.async_validate_input(
                         validation_input
                     )
-                except TimeoutError, ClientError:
+                except (TimeoutError, ClientError):
                     errors["base"] = "cannot_connect"
                 except BadCredentialsException:
                     errors["base"] = "invalid_auth"
@@ -240,7 +281,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input:
             user_input[CONF_ACCOUNT_TYPE] = self._default_account_type
             issue_token = user_input.get(CONF_ISSUE_TOKEN, "").strip()
-            cookies = user_input.get(CONF_COOKIES, "").strip()
+            cookies = self._clean_cookies(user_input.get(CONF_COOKIES, "").strip())
             # Store stripped values back so downstream validation and API calls
             # use the normalized credentials
             user_input[CONF_ISSUE_TOKEN] = issue_token
@@ -257,7 +298,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     [issue_token, cookies, email] = await self.async_validate_input(
                         user_input
                     )
-                except TimeoutError, ClientError:
+                except (TimeoutError, ClientError):
                     errors["base"] = "cannot_connect"
                 except BadCredentialsException:
                     errors["base"] = "invalid_auth"

--- a/custom_components/nest_protect/config_flow.py
+++ b/custom_components/nest_protect/config_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
-from typing import Any, cast
+from typing import Any, Final, cast
 
 import voluptuous as vol
 from aiohttp import ClientError
@@ -34,24 +34,26 @@ DESCRIPTION_PLACEHOLDERS = {
     "extension_download_url": "https://github.com/iMicknl/ha-nest-protect/releases/latest/download/nest-auth-helper.zip",
 }
 
-REQUIRED_COOKIE_NAMES: set[str] = {
-    "NID",
-    "__Secure-3PSID",
-    "__Secure-3PAPISID",
-    "__Host-3PLSID",
-    "__Secure-3PSIDCC",
-    "APISID",
-    "SAPISID",
-    "HSID",
-    "SSID",
-    "SID",
-    "__Secure-1PSID",
-    "__Secure-1PAPISID",
-    "__Host-1PLSID",
-    "__Secure-1PSIDCC",
-    "SIDCC",
-    "LSID",
-}
+REQUIRED_COOKIE_NAMES: Final[frozenset[str]] = frozenset(
+    {
+        "NID",
+        "__Secure-3PSID",
+        "__Secure-3PAPISID",
+        "__Host-3PLSID",
+        "__Secure-3PSIDCC",
+        "APISID",
+        "SAPISID",
+        "HSID",
+        "SSID",
+        "SID",
+        "__Secure-1PSID",
+        "__Secure-1PAPISID",
+        "__Host-1PLSID",
+        "__Secure-1PSIDCC",
+        "SIDCC",
+        "LSID",
+    }
+)
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -210,7 +212,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
                 issue_token = decoded["issue_token"]
                 cookies = self._clean_cookies(decoded["cookies"])
-            except (ValueError, KeyError, json.JSONDecodeError):
+            except ValueError, KeyError, json.JSONDecodeError:
                 errors[CONF_AUTH_CODE] = "invalid_code"
 
             if not errors and (
@@ -229,7 +231,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     [issue_token, cookies, email] = await self.async_validate_input(
                         validation_input
                     )
-                except (TimeoutError, ClientError):
+                except TimeoutError, ClientError:
                     errors["base"] = "cannot_connect"
                 except BadCredentialsException:
                     errors["base"] = "invalid_auth"
@@ -298,7 +300,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     [issue_token, cookies, email] = await self.async_validate_input(
                         user_input
                     )
-                except (TimeoutError, ClientError):
+                except TimeoutError, ClientError:
                     errors["base"] = "cannot_connect"
                 except BadCredentialsException:
                     errors["base"] = "invalid_auth"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.nest_protect.config_flow import ConfigFlow
 from custom_components.nest_protect.const import DOMAIN
 from custom_components.nest_protect.pynest.exceptions import BadCredentialsException
 
@@ -177,3 +178,79 @@ async def test_reauth_shows_auth_method(hass: HomeAssistant) -> None:
     result = await entry.start_reauth_flow(hass)
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "auth_method"
+
+
+class TestCleanCookies:
+    """Tests for the _clean_cookies static method."""
+
+    def test_strips_unnecessary_cookies(self) -> None:
+        """Test that non-essential cookies are removed."""
+        raw = "1P_JAR=value1; CONSENT=YES; SID=abc123; HSID=def456; __Secure-3PSIDTS=extra"
+        result = ConfigFlow._clean_cookies(raw)
+        assert "SID=abc123" in result
+        assert "HSID=def456" in result
+        assert "1P_JAR" not in result
+        assert "CONSENT" not in result
+        assert "__Secure-3PSIDTS" not in result
+
+    def test_keeps_all_required_cookies(self) -> None:
+        """Test that all required Google auth cookies are preserved."""
+        raw = "NID=nid; __Secure-3PSID=psid; APISID=api; SAPISID=sapi; HSID=h; SSID=s; SID=sid"
+        result = ConfigFlow._clean_cookies(raw)
+        assert "NID=nid" in result
+        assert "__Secure-3PSID=psid" in result
+        assert "APISID=api" in result
+        assert "SAPISID=sapi" in result
+        assert "HSID=h" in result
+        assert "SSID=s" in result
+        assert "SID=sid" in result
+
+    def test_returns_original_when_no_matches(self) -> None:
+        """Test that original cookies are returned when no known cookies found."""
+        raw = "unknown1=val1; unknown2=val2"
+        result = ConfigFlow._clean_cookies(raw)
+        assert result == raw
+
+    def test_handles_whitespace(self) -> None:
+        """Test that extra whitespace in cookies is handled."""
+        raw = "  SID=abc  ;  HSID=def  ;  APISID=ghi  "
+        result = ConfigFlow._clean_cookies(raw)
+        assert "SID=abc" in result
+        assert "HSID=def" in result
+        assert "APISID=ghi" in result
+
+
+async def test_account_link_cleans_cookies(hass: HomeAssistant) -> None:
+    """Test that account_link step cleans cookies before validation."""
+    issue_token = "https://accounts.google.com/o/oauth2/iframerpc?action=issueToken&response_type=token%20id_token&login_hint=hint123&client_id=733249279899-44tchle2kaa9afr5v9ov7jbuojfr9lrq.apps.googleusercontent.com&origin=https%3A%2F%2Fhome.nest.com&scope=openid+profile+email+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fnest-account&ss_domain=https%3A%2F%2Fhome.nest.com"
+    dirty_cookies = "1P_JAR=extra; CONSENT=YES; SID=abc123456789012345678901234567890; HSID=def1234567890; SSID=ghi1234567890; APISID=jkl1234567890; SAPISID=mno1234567890; __Secure-3PSIDTS=extra"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"account_type": "production"},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"method": "manual"},
+    )
+
+    with patch(
+        "custom_components.nest_protect.config_flow.ConfigFlow.async_validate_input",
+        new_callable=AsyncMock,
+    ) as mock_validate:
+        mock_validate.return_value = [issue_token, "cleaned", "user@example.com"]
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"issue_token": issue_token, "cookies": dirty_cookies},
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    # Verify the cookies passed to validate_input were cleaned
+    call_args = mock_validate.call_args[0][0]
+    assert "1P_JAR" not in call_args["cookies"]
+    assert "CONSENT" not in call_args["cookies"]
+    assert "__Secure-3PSIDTS" not in call_args["cookies"]
+    assert "SID=abc123456789012345678901234567890" in call_args["cookies"]


### PR DESCRIPTION
## Summary
- Add cookie cleaning that strips unnecessary cookies (e.g. `1P_JAR`, `CONSENT`, `__Secure-3PSIDTS`) during config flow setup
- Only required Google auth cookies are preserved, reducing auth failures from non-incognito browser sessions
- Applied in both manual credential entry and Chrome extension auth flows
- Fix bare-tuple exception syntax (`except A, B:` → `except (A, B):`)

Resolves part of #280 (Check and clean cookies)

## Test plan
- [ ] Enter cookies from a non-incognito session with extra cookies — verify they are stripped
- [ ] Enter cookies from an incognito session — verify they pass through unchanged
- [ ] Verify auth still works after cleaning