### PR TITLE
Add entity translations with Dutch support

### DIFF
--- a/custom_components/nest_protect/binary_sensor.py
+++ b/custom_components/nest_protect/binary_sensor.py
@@ -37,25 +37,25 @@ class NestProtectBinarySensorDescription(
 BINARY_SENSOR_DESCRIPTIONS: list[BinarySensorEntityDescription] = [
     NestProtectBinarySensorDescription(
         key="co_status",
-        name="CO Status",
+        translation_key="co_status",
         device_class=BinarySensorDeviceClass.CO,
         value_fn=lambda state: state != 0,
     ),
     NestProtectBinarySensorDescription(
         key="smoke_status",
-        name="Smoke Status",
+        translation_key="smoke_status",
         device_class=BinarySensorDeviceClass.SMOKE,
         value_fn=lambda state: state != 0,
     ),
     NestProtectBinarySensorDescription(
         key="heat_status",
-        name="Heat Status",
+        translation_key="heat_status",
         device_class=BinarySensorDeviceClass.HEAT,
         value_fn=lambda state: state != 0,
     ),
     NestProtectBinarySensorDescription(
         key="component_speaker_test_passed",
-        name="Speaker Test",
+        translation_key="component_speaker_test_passed",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:speaker-wireless",
@@ -63,21 +63,21 @@ BINARY_SENSOR_DESCRIPTIONS: list[BinarySensorEntityDescription] = [
     ),
     NestProtectBinarySensorDescription(
         key="battery_health_state",
-        name="Battery Health",
+        translation_key="battery_health_state",
         device_class=BinarySensorDeviceClass.BATTERY,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda state: state,
     ),
     NestProtectBinarySensorDescription(
         key="is_online",
-        name="Online",
+        translation_key="is_online",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda state: state,
     ),
     NestProtectBinarySensorDescription(
         key="component_smoke_test_passed",
-        name="Smoke Test",
+        translation_key="component_smoke_test_passed",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:smoke",
@@ -85,7 +85,7 @@ BINARY_SENSOR_DESCRIPTIONS: list[BinarySensorEntityDescription] = [
     ),
     NestProtectBinarySensorDescription(
         key="component_co_test_passed",
-        name="CO Test",
+        translation_key="component_co_test_passed",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:molecule-co",
@@ -93,7 +93,7 @@ BINARY_SENSOR_DESCRIPTIONS: list[BinarySensorEntityDescription] = [
     ),
     NestProtectBinarySensorDescription(
         key="component_wifi_test_passed",
-        name="WiFi Test",
+        translation_key="component_wifi_test_passed",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:wifi",
@@ -101,7 +101,7 @@ BINARY_SENSOR_DESCRIPTIONS: list[BinarySensorEntityDescription] = [
     ),
     NestProtectBinarySensorDescription(
         key="component_led_test_passed",
-        name="LED Test",
+        translation_key="component_led_test_passed",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:led-off",
@@ -109,7 +109,7 @@ BINARY_SENSOR_DESCRIPTIONS: list[BinarySensorEntityDescription] = [
     ),
     NestProtectBinarySensorDescription(
         key="component_pir_test_passed",
-        name="PIR Test",
+        translation_key="component_pir_test_passed",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:run",
@@ -117,7 +117,7 @@ BINARY_SENSOR_DESCRIPTIONS: list[BinarySensorEntityDescription] = [
     ),
     NestProtectBinarySensorDescription(
         key="component_buzzer_test_passed",
-        name="Buzzer Test",
+        translation_key="component_buzzer_test_passed",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:alarm-bell",
@@ -134,7 +134,7 @@ BINARY_SENSOR_DESCRIPTIONS: list[BinarySensorEntityDescription] = [
     # ),
     NestProtectBinarySensorDescription(
         key="component_hum_test_passed",
-        name="Humidity Test",
+        translation_key="component_hum_test_passed",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:water-percent",
@@ -142,7 +142,7 @@ BINARY_SENSOR_DESCRIPTIONS: list[BinarySensorEntityDescription] = [
     ),
     NestProtectBinarySensorDescription(
         key="removed_from_base",
-        name="Removed from Base",
+        translation_key="removed_from_base",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:tray-remove",
@@ -150,14 +150,14 @@ BINARY_SENSOR_DESCRIPTIONS: list[BinarySensorEntityDescription] = [
     ),
     NestProtectBinarySensorDescription(
         key="auto_away",
-        name="Occupancy",
+        translation_key="auto_away",
         device_class=BinarySensorDeviceClass.OCCUPANCY,
         wired_only=True,
         value_fn=lambda state: not state,
     ),
     NestProtectBinarySensorDescription(
         key="line_power_present",
-        name="Line Power",
+        translation_key="line_power_present",
         device_class=BinarySensorDeviceClass.POWER,
         entity_category=EntityCategory.DIAGNOSTIC,
         wired_only=True,

--- a/custom_components/nest_protect/entity.py
+++ b/custom_components/nest_protect/entity.py
@@ -67,7 +67,7 @@ class NestEntity(Entity):
                 ),
                 suggested_area=self.area,
                 configuration_url="https://home.nest.com/protect/"
-                + self.bucket.value["structure_id"],
+                + self.bucket.value["structure_id"],  # TODO change url based on device
             )
 
         if self.bucket.object_key.startswith("kryptonite."):
@@ -77,7 +77,9 @@ class NestEntity(Entity):
 
             return DeviceInfo(
                 identifiers={(DOMAIN, identifier)},
-                name=f"Nest Temperature Sensor ({label})" if label else "Nest Temperature Sensor",
+                name=f"Nest Temperature Sensor ({label})"
+                if label
+                else "Nest Temperature Sensor",
                 manufacturer="Google",
                 model=self.bucket.value.get("model"),
                 suggested_area=self.area,

--- a/custom_components/nest_protect/entity.py
+++ b/custom_components/nest_protect/entity.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 class NestEntity(Entity):
     """Class to describe an Nest entity and link it to a device."""
 
+    _attr_has_entity_name = True
     _attr_should_poll = False
 
     def __init__(
@@ -37,28 +38,19 @@ class NestEntity(Entity):
 
         self._attr_unique_id = bucket.object_key
         self._attr_attribution = ATTRIBUTION
-        self._attr_name = self.device_name()
         self._attr_device_info = self.generate_device_info()
 
-    def device_name(self) -> str | None:
-        """Generate device name."""
+    def _device_label(self) -> str:
+        """Generate device label from description or area."""
         if label := self.bucket.value.get("description"):
-            name = label
-        elif self.area:
-            name = self.area
-        else:
-            name = ""
-
-        if self.bucket.object_key.startswith("topaz."):
-            return f"Nest Protect ({name})"
-
-        if self.bucket.object_key.startswith("kryptonite."):
-            return f"Nest Temperature Sensor ({name})"
-
-        return None
+            return label
+        if self.area:
+            return self.area
+        return ""
 
     def generate_device_info(self) -> DeviceInfo | None:
         """Generate device info."""
+        label = self._device_label()
 
         if self.bucket.object_key.startswith("topaz."):
             return DeviceInfo(
@@ -66,7 +58,7 @@ class NestEntity(Entity):
                     (dr.CONNECTION_NETWORK_MAC, self.bucket.value["wifi_mac_address"])
                 },
                 identifiers={(DOMAIN, self.bucket.value["serial_number"])},
-                name=self._attr_name,
+                name=f"Nest Protect ({label})" if label else "Nest Protect",
                 manufacturer="Google",
                 model=self.bucket.value["model"],
                 sw_version=self.bucket.value["software_version"],
@@ -75,7 +67,7 @@ class NestEntity(Entity):
                 ),
                 suggested_area=self.area,
                 configuration_url="https://home.nest.com/protect/"
-                + self.bucket.value["structure_id"],  # TODO change url based on device
+                + self.bucket.value["structure_id"],
             )
 
         if self.bucket.object_key.startswith("kryptonite."):
@@ -85,7 +77,7 @@ class NestEntity(Entity):
 
             return DeviceInfo(
                 identifiers={(DOMAIN, identifier)},
-                name=self._attr_name,
+                name=f"Nest Temperature Sensor ({label})" if label else "Nest Temperature Sensor",
                 manufacturer="Google",
                 model=self.bucket.value.get("model"),
                 suggested_area=self.area,
@@ -121,7 +113,6 @@ class NestDescriptiveEntity(NestEntity):
     ) -> None:
         """Initialize the device."""
         super().__init__(bucket, description, areas, client)
-        self._attr_name = f"{super().name} {self.entity_description.name}"
         self._attr_unique_id = f"{super().unique_id}-{self.entity_description.key}"
 
 

--- a/custom_components/nest_protect/select.py
+++ b/custom_components/nest_protect/select.py
@@ -26,7 +26,6 @@ SENSOR_DESCRIPTIONS: list[SelectEntityDescription] = [
     NestProtectSelectDescription(
         key="night_light_brightness",
         translation_key="night_light_brightness",
-        name="Brightness",
         icon="mdi:lightbulb-on",
         options=[*PRESET_TO_BRIGHTNESS],
         entity_category=EntityCategory.CONFIG,

--- a/custom_components/nest_protect/sensor.py
+++ b/custom_components/nest_protect/sensor.py
@@ -64,26 +64,16 @@ class NestProtectSensorDescription(SensorEntityDescription):
 SENSOR_DESCRIPTIONS: list[NestProtectSensorDescription] = [
     NestProtectSensorDescription(
         key="battery_level",
-        name="Battery Level",
+        translation_key="battery_level",
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
         entity_category=EntityCategory.DIAGNOSTIC,
         bucket_type=BucketType.KRYPTONITE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    # TODO Due to duplicate keys, this sensor is not available yet
-    # NestProtectSensorDescription(
-    #     key="battery_level",
-    #     name="Battery Voltage",
-    #     value_fn=lambda state: round(state / 1000, 3),
-    #     device_class=SensorDeviceClass.BATTERY,
-    #     native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-    #     entity_category=EntityCategory.DIAGNOSTIC,
-    #     bucket_type=BucketType.TOPAZ,
-    # ),
     NestProtectSensorDescription(
         key="battery_level",
-        name="Battery Level",
+        translation_key="battery_level",
         value_fn=milli_volt_to_percentage,
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
@@ -92,37 +82,34 @@ SENSOR_DESCRIPTIONS: list[NestProtectSensorDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
     ),
     NestProtectSensorDescription(
-        name="Replace By",
         key="replace_by_date_utc_secs",
+        translation_key="replace_by_date_utc_secs",
         value_fn=datetime.datetime.utcfromtimestamp,
         device_class=SensorDeviceClass.DATE,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     NestProtectSensorDescription(
-        name="Last Audio Self Test",
         key="last_audio_self_test_end_utc_secs",
+        translation_key="last_audio_self_test_end_utc_secs",
         value_fn=datetime.datetime.utcfromtimestamp,
         device_class=SensorDeviceClass.DATE,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     NestProtectSensorDescription(
-        name="Last Manual Test",
         key="latest_manual_test_end_utc_secs",
+        translation_key="latest_manual_test_end_utc_secs",
         value_fn=datetime.datetime.utcfromtimestamp,
         device_class=SensorDeviceClass.DATE,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     NestProtectSensorDescription(
-        name="Temperature",
         key="current_temperature",
+        translation_key="current_temperature",
         value_fn=lambda state: round(state, 2),
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    # TODO Add Color Status (gray, green, yellow, red)
-    # TODO Smoke Status (OK, Warning, Emergency)
-    # TODO CO Status (OK, Warning, Emergency)
 ]
 
 

--- a/custom_components/nest_protect/sensor.py
+++ b/custom_components/nest_protect/sensor.py
@@ -71,6 +71,16 @@ SENSOR_DESCRIPTIONS: list[NestProtectSensorDescription] = [
         bucket_type=BucketType.KRYPTONITE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    # TODO Due to duplicate keys, this sensor is not available yet
+    # NestProtectSensorDescription(
+    #     key="battery_level",
+    #     name="Battery Voltage",
+    #     value_fn=lambda state: round(state / 1000, 3),
+    #     device_class=SensorDeviceClass.BATTERY,
+    #     native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+    #     entity_category=EntityCategory.DIAGNOSTIC,
+    #     bucket_type=BucketType.TOPAZ,
+    # ),
     NestProtectSensorDescription(
         key="battery_level",
         translation_key="battery_level",
@@ -110,6 +120,9 @@ SENSOR_DESCRIPTIONS: list[NestProtectSensorDescription] = [
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    # TODO Add Color Status (gray, green, yellow, red)
+    # TODO Smoke Status (OK, Warning, Emergency)
+    # TODO CO Status (OK, Warning, Emergency)
 ]
 
 

--- a/custom_components/nest_protect/strings.json
+++ b/custom_components/nest_protect/strings.json
@@ -51,14 +51,95 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "co_status": {
+        "name": "CO status"
+      },
+      "smoke_status": {
+        "name": "Smoke status"
+      },
+      "heat_status": {
+        "name": "Heat status"
+      },
+      "component_speaker_test_passed": {
+        "name": "Speaker test"
+      },
+      "battery_health_state": {
+        "name": "Battery health"
+      },
+      "is_online": {
+        "name": "Online"
+      },
+      "component_smoke_test_passed": {
+        "name": "Smoke test"
+      },
+      "component_co_test_passed": {
+        "name": "CO test"
+      },
+      "component_wifi_test_passed": {
+        "name": "Wi-Fi test"
+      },
+      "component_led_test_passed": {
+        "name": "LED test"
+      },
+      "component_pir_test_passed": {
+        "name": "PIR test"
+      },
+      "component_buzzer_test_passed": {
+        "name": "Buzzer test"
+      },
+      "component_hum_test_passed": {
+        "name": "Humidity test"
+      },
+      "removed_from_base": {
+        "name": "Removed from base"
+      },
+      "auto_away": {
+        "name": "Occupancy"
+      },
+      "line_power_present": {
+        "name": "Line power"
+      }
+    },
+    "sensor": {
+      "battery_level": {
+        "name": "Battery level"
+      },
+      "replace_by_date_utc_secs": {
+        "name": "Replace by"
+      },
+      "last_audio_self_test_end_utc_secs": {
+        "name": "Last audio self-test"
+      },
+      "latest_manual_test_end_utc_secs": {
+        "name": "Last manual test"
+      },
+      "current_temperature": {
+        "name": "Temperature"
+      }
+    },
     "select": {
       "night_light_brightness": {
-        "name": "Night Light Brightness",
+        "name": "Night light brightness",
         "state": {
           "low": "Low",
           "medium": "Medium",
           "high": "High"
         }
+      }
+    },
+    "switch": {
+      "night_light_enable": {
+        "name": "Pathlight"
+      },
+      "ntp_green_led_enable": {
+        "name": "Nightly promise"
+      },
+      "heads_up_enable": {
+        "name": "Heads-Up"
+      },
+      "steam_detection_enable": {
+        "name": "Steam check"
       }
     }
   }

--- a/custom_components/nest_protect/switch.py
+++ b/custom_components/nest_protect/switch.py
@@ -36,25 +36,25 @@ PRESET_TO_BRIGHTNESS = {v: k for k, v in BRIGHTNESS_TO_PRESET.items()}
 SWITCH_DESCRIPTIONS: list[SwitchEntityDescription] = [
     NestProtectSwitchDescription(
         key="night_light_enable",
-        name="Pathlight",
+        translation_key="night_light_enable",
         entity_category=EntityCategory.CONFIG,
         icon="mdi:weather-night",
     ),
     NestProtectSwitchDescription(
         key="ntp_green_led_enable",
-        name="Nightly Promise",
+        translation_key="ntp_green_led_enable",
         entity_category=EntityCategory.CONFIG,
         icon="mdi:led-off",
     ),
     NestProtectSwitchDescription(
         key="heads_up_enable",
-        name="Heads-Up",
+        translation_key="heads_up_enable",
         entity_category=EntityCategory.CONFIG,
         icon="mdi:exclamation-thick",
     ),
     NestProtectSwitchDescription(
         key="steam_detection_enable",
-        name="Steam Check",
+        translation_key="steam_detection_enable",
         entity_category=EntityCategory.CONFIG,
         icon="mdi:pot-steam",
     ),

--- a/custom_components/nest_protect/translations/en.json
+++ b/custom_components/nest_protect/translations/en.json
@@ -51,14 +51,95 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "co_status": {
+        "name": "CO status"
+      },
+      "smoke_status": {
+        "name": "Smoke status"
+      },
+      "heat_status": {
+        "name": "Heat status"
+      },
+      "component_speaker_test_passed": {
+        "name": "Speaker test"
+      },
+      "battery_health_state": {
+        "name": "Battery health"
+      },
+      "is_online": {
+        "name": "Online"
+      },
+      "component_smoke_test_passed": {
+        "name": "Smoke test"
+      },
+      "component_co_test_passed": {
+        "name": "CO test"
+      },
+      "component_wifi_test_passed": {
+        "name": "Wi-Fi test"
+      },
+      "component_led_test_passed": {
+        "name": "LED test"
+      },
+      "component_pir_test_passed": {
+        "name": "PIR test"
+      },
+      "component_buzzer_test_passed": {
+        "name": "Buzzer test"
+      },
+      "component_hum_test_passed": {
+        "name": "Humidity test"
+      },
+      "removed_from_base": {
+        "name": "Removed from base"
+      },
+      "auto_away": {
+        "name": "Occupancy"
+      },
+      "line_power_present": {
+        "name": "Line power"
+      }
+    },
+    "sensor": {
+      "battery_level": {
+        "name": "Battery level"
+      },
+      "replace_by_date_utc_secs": {
+        "name": "Replace by"
+      },
+      "last_audio_self_test_end_utc_secs": {
+        "name": "Last audio self-test"
+      },
+      "latest_manual_test_end_utc_secs": {
+        "name": "Last manual test"
+      },
+      "current_temperature": {
+        "name": "Temperature"
+      }
+    },
     "select": {
       "night_light_brightness": {
-        "name": "Night Light Brightness",
+        "name": "Night light brightness",
         "state": {
           "low": "Low",
           "medium": "Medium",
           "high": "High"
         }
+      }
+    },
+    "switch": {
+      "night_light_enable": {
+        "name": "Pathlight"
+      },
+      "ntp_green_led_enable": {
+        "name": "Nightly promise"
+      },
+      "heads_up_enable": {
+        "name": "Heads-Up"
+      },
+      "steam_detection_enable": {
+        "name": "Steam check"
       }
     }
   }

--- a/custom_components/nest_protect/translations/nl.json
+++ b/custom_components/nest_protect/translations/nl.json
@@ -1,0 +1,146 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Account is al geconfigureerd",
+      "reauth_successful": "Herauthenticatie geslaagd!"
+    },
+    "error": {
+      "cannot_connect": "Kan niet verbinden",
+      "invalid_auth": "Ongeldige authenticatie",
+      "invalid_issue_token": "Ongeldige issue token URL. Moet beginnen met {accounts_url} en de issueToken actie bevatten.",
+      "invalid_cookies": "Ongeldig cookies-formaat. Zorg ervoor dat je de volledige cookie-header van het oauth2/iframe-verzoek hebt gekopieerd.",
+      "invalid_code": "Ongeldige authenticatiecode. Controleer of je de volledige code van de extensie hebt gekopieerd.",
+      "unknown": "Onverwachte fout"
+    },
+    "step": {
+      "user": {
+        "description": "Selecteer je accounttype. De meeste gebruikers moeten Google Account selecteren. Field Test is alleen beschikbaar voor geselecteerde testers in het Google Field Test-programma.",
+        "data": {
+          "account_type": "Accounttype"
+        }
+      },
+      "auth_method": {
+        "title": "Authenticatiemethode",
+        "description": "Kies hoe je je Nest-account wilt verbinden. De Chrome-extensiemethode wordt aanbevolen voor de meeste gebruikers.",
+        "data": {
+          "method": "Methode"
+        }
+      },
+      "extension": {
+        "title": "Verbinden met Chrome-extensie",
+        "description": "1. [Download de Nest Auth Helper-extensie]({extension_download_url})\n2. Pak uit en laad in Chrome (chrome://extensions → Ontwikkelaarsmodus → Uitgepakt laden)\n3. Log in op [home.nest.com]({nest_url})\n4. Klik op het extensie-icoon → klik op **Extract Credentials**\n5. Kopieer de code en plak deze hieronder\n\n⚠️ Deel deze code niet — deze bevat je sessiegegevens.",
+        "data": {
+          "auth_code": "Authenticatiecode"
+        },
+        "data_description": {
+          "auth_code": "De code die wordt weergegeven door de Nest Auth Helper-extensie"
+        }
+      },
+      "account_link": {
+        "title": "Verbind je Nest-account",
+        "description": "Volg deze stappen om je inloggegevens te verkrijgen:\n\n1. Open een **Incognito/Privé** browservenster\n2. Schakel **cookies van derden** in bij de browserinstellingen\n3. Ga naar [home.nest.com]({nest_url}) en log in met Google\n4. Open **Ontwikkelaarstools** (F12) → tabblad **Netwerk** → Vink **Logboek bewaren** aan\n5. Typ `issueToken` in het filtervak en kopieer de volledige **Aanvraag-URL**\n6. Typ `oauth2/iframe` in het filtervak, klik op het laatste verzoek en kopieer de volledige **Cookie**-headerwaarde\n\n⚠️ Log niet uit bij home.nest.com na het kopiëren van de inloggegevens",
+        "data": {
+          "issue_token": "Issue Token URL",
+          "cookies": "Cookies"
+        },
+        "data_description": {
+          "issue_token": "Volledige URL beginnend met {issue_token_prefix}...",
+          "cookies": "Volledige cookie-string van de oauth2/iframe-verzoekheaders"
+        }
+      }
+    }
+  },
+  "entity": {
+    "binary_sensor": {
+      "co_status": {
+        "name": "CO-status"
+      },
+      "smoke_status": {
+        "name": "Rookstatus"
+      },
+      "heat_status": {
+        "name": "Hittestatus"
+      },
+      "component_speaker_test_passed": {
+        "name": "Luidsprekerstest"
+      },
+      "battery_health_state": {
+        "name": "Batterijstatus"
+      },
+      "is_online": {
+        "name": "Online"
+      },
+      "component_smoke_test_passed": {
+        "name": "Rooktest"
+      },
+      "component_co_test_passed": {
+        "name": "CO-test"
+      },
+      "component_wifi_test_passed": {
+        "name": "Wi-Fi-test"
+      },
+      "component_led_test_passed": {
+        "name": "LED-test"
+      },
+      "component_pir_test_passed": {
+        "name": "PIR-test"
+      },
+      "component_buzzer_test_passed": {
+        "name": "Zoemertest"
+      },
+      "component_hum_test_passed": {
+        "name": "Vochtigheidstest"
+      },
+      "removed_from_base": {
+        "name": "Verwijderd van basis"
+      },
+      "auto_away": {
+        "name": "Aanwezigheid"
+      },
+      "line_power_present": {
+        "name": "Netstroom"
+      }
+    },
+    "sensor": {
+      "battery_level": {
+        "name": "Batterijniveau"
+      },
+      "replace_by_date_utc_secs": {
+        "name": "Vervangen voor"
+      },
+      "last_audio_self_test_end_utc_secs": {
+        "name": "Laatste audio-zelftest"
+      },
+      "latest_manual_test_end_utc_secs": {
+        "name": "Laatste handmatige test"
+      },
+      "current_temperature": {
+        "name": "Temperatuur"
+      }
+    },
+    "select": {
+      "night_light_brightness": {
+        "name": "Nachtlamp helderheid",
+        "state": {
+          "low": "Laag",
+          "medium": "Gemiddeld",
+          "high": "Hoog"
+        }
+      }
+    },
+    "switch": {
+      "night_light_enable": {
+        "name": "Padverlichting"
+      },
+      "ntp_green_led_enable": {
+        "name": "Nachtbelofte"
+      },
+      "heads_up_enable": {
+        "name": "Heads-Up"
+      },
+      "steam_detection_enable": {
+        "name": "Stoomcontrole"
+      }
+    }
+  }
+}

--- a/custom_components/nest_protect/translations/nl.json
+++ b/custom_components/nest_protect/translations/nl.json
@@ -106,7 +106,7 @@
         "name": "Batterijniveau"
       },
       "replace_by_date_utc_secs": {
-        "name": "Vervangen voor"
+        "name": "Vervangdatum"
       },
       "last_audio_self_test_end_utc_secs": {
         "name": "Laatste geluidscheck"

--- a/custom_components/nest_protect/translations/nl.json
+++ b/custom_components/nest_protect/translations/nl.json
@@ -7,8 +7,8 @@
     "error": {
       "cannot_connect": "Kan niet verbinden",
       "invalid_auth": "Ongeldige authenticatie",
-      "invalid_issue_token": "Ongeldige issue token URL. Moet beginnen met {accounts_url} en de issueToken actie bevatten.",
-      "invalid_cookies": "Ongeldig cookies-formaat. Zorg ervoor dat je de volledige cookie-header van het oauth2/iframe-verzoek hebt gekopieerd.",
+      "invalid_issue_token": "Ongeldige issue token URL. Moet beginnen met {accounts_url} en de issueToken-actie bevatten.",
+      "invalid_cookies": "Ongeldig cookie-formaat. Zorg ervoor dat je de volledige cookie-header van het oauth2/iframe-verzoek hebt gekopieerd.",
       "invalid_code": "Ongeldige authenticatiecode. Controleer of je de volledige code van de extensie hebt gekopieerd.",
       "unknown": "Onverwachte fout"
     },
@@ -38,7 +38,7 @@
       },
       "account_link": {
         "title": "Verbind je Nest-account",
-        "description": "Volg deze stappen om je inloggegevens te verkrijgen:\n\n1. Open een **Incognito/Privé** browservenster\n2. Schakel **cookies van derden** in bij de browserinstellingen\n3. Ga naar [home.nest.com]({nest_url}) en log in met Google\n4. Open **Ontwikkelaarstools** (F12) → tabblad **Netwerk** → Vink **Logboek bewaren** aan\n5. Typ `issueToken` in het filtervak en kopieer de volledige **Aanvraag-URL**\n6. Typ `oauth2/iframe` in het filtervak, klik op het laatste verzoek en kopieer de volledige **Cookie**-headerwaarde\n\n⚠️ Log niet uit bij home.nest.com na het kopiëren van de inloggegevens",
+        "description": "Volg deze stappen om je inloggegevens te verkrijgen:\n\n1. Open een **Incognito/Privé** browservenster\n2. Schakel **cookies van derden** in bij de browserinstellingen\n3. Ga naar [home.nest.com]({nest_url}) en log in met Google\n4. Open **DevTools** (F12) → tabblad **Network** → Vink **Preserve log** aan\n5. Typ `issueToken` in het filtervak en kopieer de volledige **Request URL**\n6. Typ `oauth2/iframe` in het filtervak, klik op het laatste verzoek en kopieer de volledige **Cookie**-headerwaarde\n\n⚠️ Log niet uit bij home.nest.com na het kopiëren van de inloggegevens",
         "data": {
           "issue_token": "Issue Token URL",
           "cookies": "Cookies"
@@ -59,10 +59,10 @@
         "name": "Rookstatus"
       },
       "heat_status": {
-        "name": "Hittestatus"
+        "name": "Warmtestatus"
       },
       "component_speaker_test_passed": {
-        "name": "Luidsprekerstest"
+        "name": "Speakertest"
       },
       "battery_health_state": {
         "name": "Batterijstatus"
@@ -77,7 +77,7 @@
         "name": "CO-test"
       },
       "component_wifi_test_passed": {
-        "name": "Wi-Fi-test"
+        "name": "Wifi-test"
       },
       "component_led_test_passed": {
         "name": "LED-test"
@@ -86,7 +86,7 @@
         "name": "PIR-test"
       },
       "component_buzzer_test_passed": {
-        "name": "Zoemertest"
+        "name": "Sirenetest"
       },
       "component_hum_test_passed": {
         "name": "Vochtigheidstest"
@@ -109,10 +109,10 @@
         "name": "Vervangen voor"
       },
       "last_audio_self_test_end_utc_secs": {
-        "name": "Laatste audio-zelftest"
+        "name": "Laatste geluidscheck"
       },
       "latest_manual_test_end_utc_secs": {
-        "name": "Laatste handmatige test"
+        "name": "Laatste veiligheidscontrole"
       },
       "current_temperature": {
         "name": "Temperatuur"
@@ -120,7 +120,7 @@
     },
     "select": {
       "night_light_brightness": {
-        "name": "Nachtlamp helderheid",
+        "name": "Lichtpad helderheid",
         "state": {
           "low": "Laag",
           "medium": "Gemiddeld",
@@ -130,13 +130,13 @@
     },
     "switch": {
       "night_light_enable": {
-        "name": "Padverlichting"
+        "name": "Lichtpad"
       },
       "ntp_green_led_enable": {
         "name": "Nachtbelofte"
       },
       "heads_up_enable": {
-        "name": "Heads-Up"
+        "name": "Let op"
       },
       "steam_detection_enable": {
         "name": "Stoomcontrole"

--- a/custom_components/nest_protect/translations/nl.json
+++ b/custom_components/nest_protect/translations/nl.json
@@ -133,7 +133,7 @@
         "name": "Lichtpad"
       },
       "ntp_green_led_enable": {
-        "name": "Nachtbelofte"
+        "name": "Nachtwacht"
       },
       "heads_up_enable": {
         "name": "Let op-meldingen"

--- a/custom_components/nest_protect/translations/nl.json
+++ b/custom_components/nest_protect/translations/nl.json
@@ -136,7 +136,7 @@
         "name": "Nachtbelofte"
       },
       "heads_up_enable": {
-        "name": "Let op"
+        "name": "Let op-meldingen"
       },
       "steam_detection_enable": {
         "name": "Stoomcontrole"


### PR DESCRIPTION
## Summary
- Migrate all entities to use `has_entity_name = True` with `translation_key` for proper HA translation support
- Add complete entity translations for all binary sensors, sensors, selects, and switches
- Add Dutch (nl) translation for both config flow and entity names
- Remove hardcoded `name` attributes from entity descriptions

## Test plan
- [ ] Verify entity names appear correctly in English
- [ ] Verify entity names appear correctly when HA language is set to Dutch
- [ ] Verify device names remain unchanged (Nest Protect / Nest Temperature Sensor with area label)