### PR TITLE
Add Firefox support and add debug logs in Chrome extension

### DIFF
--- a/chrome_extension/background.js
+++ b/chrome_extension/background.js
@@ -1,8 +1,19 @@
+const browser = globalThis.browser ?? globalThis.chrome;
+const isFirefox = typeof browser.runtime.getBrowserInfo === "function";
+
 let capturedData = {
   issueToken: null,
   cookies: null,
   listening: false,
 };
+
+const debugLogs = [];
+function log(msg) {
+  const entry = `${new Date().toISOString().substring(11, 23)} ${msg}`;
+  console.log("[nest-auth]", msg);
+  debugLogs.push(entry);
+  if (debugLogs.length > 200) debugLogs.shift();
+}
 
 const FIRST_PARTY_AUTH_COOKIES = new Set([
   "SID", "HSID", "SSID", "APISID", "SAPISID",
@@ -11,65 +22,81 @@ const FIRST_PARTY_AUTH_COOKIES = new Set([
 function startListening() {
   capturedData = { issueToken: null, cookies: null, listening: true };
 
-  if (!chrome.webRequest.onBeforeRequest.hasListener(captureIssueToken)) {
-    chrome.webRequest.onBeforeRequest.addListener(captureIssueToken, {
+  if (!browser.webRequest.onBeforeRequest.hasListener(captureIssueToken)) {
+    browser.webRequest.onBeforeRequest.addListener(captureIssueToken, {
       urls: ["https://accounts.google.com/o/oauth2/iframerpc*"],
       types: ["xmlhttprequest", "sub_frame", "main_frame"],
     });
   }
 
-  if (!chrome.webRequest.onSendHeaders.hasListener(captureRequestCookies)) {
-    chrome.webRequest.onSendHeaders.addListener(
+  if (!browser.webRequest.onSendHeaders.hasListener(captureRequestCookies)) {
+    const extraOpts = isFirefox ? ["requestHeaders"] : ["requestHeaders", "extraHeaders"];
+    browser.webRequest.onSendHeaders.addListener(
       captureRequestCookies,
       {
         urls: ["https://accounts.google.com/o/oauth2/iframerpc*"],
         types: ["xmlhttprequest", "sub_frame", "main_frame"],
       },
-      ["requestHeaders", "extraHeaders"]
+      extraOpts
     );
   }
 }
 
 function stopListening() {
   capturedData.listening = false;
-  if (chrome.webRequest.onBeforeRequest.hasListener(captureIssueToken)) {
-    chrome.webRequest.onBeforeRequest.removeListener(captureIssueToken);
+  if (browser.webRequest.onBeforeRequest.hasListener(captureIssueToken)) {
+    browser.webRequest.onBeforeRequest.removeListener(captureIssueToken);
   }
-  if (chrome.webRequest.onSendHeaders.hasListener(captureRequestCookies)) {
-    chrome.webRequest.onSendHeaders.removeListener(captureRequestCookies);
+  if (browser.webRequest.onSendHeaders.hasListener(captureRequestCookies)) {
+    browser.webRequest.onSendHeaders.removeListener(captureRequestCookies);
   }
 }
 
 function captureIssueToken(details) {
+  log(`onBeforeRequest: ${details.url.substring(0, 80)}`);
   if (details.url.includes("action=issueToken")) {
+    log("issueToken captured");
     capturedData.issueToken = details.url;
     checkComplete();
   }
 }
 
 function captureRequestCookies(details) {
+  log(`onSendHeaders: ${details.url.substring(0, 80)}`);
   if (!details.url.includes("action=issueToken")) return;
+
+  const cookieMap = new Map();
 
   const cookieHeader = details.requestHeaders.find(
     (h) => h.name.toLowerCase() === "cookie"
   );
-  if (!cookieHeader) return;
+  log(`cookie header found: ${!!cookieHeader} | headers: ${details.requestHeaders.map(h => h.name).join(", ")}`);
 
-  const cookieMap = new Map();
-  cookieHeader.value.split("; ").forEach((pair) => {
-    const eqIdx = pair.indexOf("=");
-    if (eqIdx > 0) {
-      cookieMap.set(pair.substring(0, eqIdx), pair.substring(eqIdx + 1));
-    }
-  });
+  if (cookieHeader) {
+    cookieHeader.value.split("; ").forEach((pair) => {
+      const eqIdx = pair.indexOf("=");
+      if (eqIdx > 0) {
+        cookieMap.set(pair.substring(0, eqIdx), pair.substring(eqIdx + 1));
+      }
+    });
+    log(`cookies from header: ${cookieMap.size}`);
+  }
 
-  chrome.cookies.getAll({ url: "https://accounts.google.com" }, (cookies) => {
+  browser.cookies.getAll({ url: "https://accounts.google.com" }).then((cookies) => {
+    log(`cookies.getAll: ${cookies?.length ?? 0} cookies [${cookies?.map(c => c.name).join(", ")}]`);
     if (cookies) {
       for (const c of cookies) {
-        if (FIRST_PARTY_AUTH_COOKIES.has(c.name) && !cookieMap.has(c.name)) {
-          cookieMap.set(c.name, c.value);
-        }
+        const relevant = cookieMap.size === 0
+          ? true
+          : FIRST_PARTY_AUTH_COOKIES.has(c.name) && !cookieMap.has(c.name);
+        if (relevant) cookieMap.set(c.name, c.value);
       }
+    }
+
+    log(`final cookieMap: ${cookieMap.size} keys [${[...cookieMap.keys()].join(", ")}]`);
+    if (cookieMap.size === 0) {
+      log("WARNING: no cookies found, aborting");
+      return;
     }
 
     capturedData.cookies = Array.from(cookieMap.entries())
@@ -83,21 +110,24 @@ function captureRequestCookies(details) {
 function checkComplete() {
   if (capturedData.issueToken && capturedData.cookies) {
     stopListening();
-    chrome.action.setBadgeText({ text: "✓" });
-    chrome.action.setBadgeBackgroundColor({ color: "#4CAF50" });
-    // Open the popup by programmatically triggering the action
-    chrome.action.openPopup();
+    browser.action.setBadgeText({ text: "✓" });
+    browser.action.setBadgeBackgroundColor({ color: "#4CAF50" });
   }
 }
 
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  if (message.action === "startCapture") {
-    startListening();
-    chrome.action.setBadgeText({ text: "..." });
-    chrome.action.setBadgeBackgroundColor({ color: "#FF9800" });
+browser.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message.action === "getLogs") {
+    sendResponse({ logs: debugLogs.slice() });
+    return false;
+  }
 
-    // Always open a fresh tab to ensure the OAuth iframe fires
-    chrome.tabs.create({ url: "https://home.nest.com/" }, () => {
+  if (message.action === "startCapture") {
+    log("startCapture received");
+    startListening();
+    browser.action.setBadgeText({ text: "..." });
+    browser.action.setBadgeBackgroundColor({ color: "#FF9800" });
+
+    browser.tabs.create({ url: "https://home.nest.com/" }).then(() => {
       sendResponse({ status: "started" });
     });
     return true;
@@ -111,7 +141,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "reset") {
     stopListening();
     capturedData = { issueToken: null, cookies: null, listening: false };
-    chrome.action.setBadgeText({ text: "" });
+    browser.action.setBadgeText({ text: "" });
     sendResponse({ status: "reset" });
     return false;
   }

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -3,6 +3,12 @@
   "name": "Nest Auth Helper",
   "version": "1.0.0",
   "description": "Extract authentication credentials for the ha-nest-protect Home Assistant integration",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "nest-auth-helper@iMicknl",
+      "strict_min_version": "109.0"
+    }
+  },
   "permissions": [
     "cookies",
     "webRequest",
@@ -13,7 +19,8 @@
     "https://accounts.google.com/*"
   ],
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "scripts": ["background.js"]
   },
   "action": {
     "default_popup": "popup.html",

--- a/chrome_extension/popup.html
+++ b/chrome_extension/popup.html
@@ -64,6 +64,57 @@ button.copy-btn:hover { background: #388e3c; }
   color: #e65100;
   margin-top: 8px;
 }
+.debug-toggle {
+  margin-top: 16px;
+  width: 100%;
+  padding: 6px;
+  background: none;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  color: #888;
+  font-size: 12px;
+  cursor: pointer;
+  text-align: left;
+}
+.debug-toggle:hover { background: #f5f5f5; border-color: #999; color: #555; }
+#debug_area {
+  margin-top: 8px;
+  background: #1e1e1e;
+  border-radius: 6px;
+  padding: 8px;
+  max-height: 180px;
+  overflow-y: auto;
+}
+#debug_log {
+  font-family: monospace;
+  font-size: 11px;
+  color: #ccc;
+  white-space: pre-wrap;
+  word-break: break-all;
+  margin: 0;
+}
+.debug-field {
+  margin-top: 8px;
+}
+.debug-field label {
+  display: block;
+  font-family: monospace;
+  font-size: 11px;
+  color: #888;
+  margin-bottom: 2px;
+}
+.debug-field textarea {
+  width: 100%;
+  height: 80px;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+  font-family: monospace;
+  font-size: 11px;
+  resize: vertical;
+  word-break: break-all;
+}
 </style>
 </head>
 <body>
@@ -80,6 +131,21 @@ button.copy-btn:hover { background: #388e3c; }
     <textarea id="auth_code" readonly></textarea>
     <button id="copy_btn" class="copy-btn">Copy Code</button>
     <p class="warning">Do not share this code — it contains your Google session credentials.</p>
+  </div>
+
+  <button id="debug_toggle" class="debug-toggle">▶ Debug logs</button>
+  <div id="debug_area" style="display:none;">
+    <pre id="debug_log">(no logs yet)</pre>
+  </div>
+  <div id="debug_decoded" style="display:none;">
+    <div class="debug-field">
+      <label for="debug_issue_token">issue_token</label>
+      <textarea id="debug_issue_token" readonly></textarea>
+    </div>
+    <div class="debug-field">
+      <label for="debug_cookies">cookies</label>
+      <textarea id="debug_cookies" readonly></textarea>
+    </div>
   </div>
 
   <script src="popup.js"></script>

--- a/chrome_extension/popup.js
+++ b/chrome_extension/popup.js
@@ -1,8 +1,57 @@
+const browser = globalThis.browser ?? globalThis.chrome;
+
 const extractBtn = document.getElementById("extract_btn");
 const copyBtn = document.getElementById("copy_btn");
 const statusArea = document.getElementById("status_area");
 const outputArea = document.getElementById("output_area");
 const authCodeField = document.getElementById("auth_code");
+const debugToggle = document.getElementById("debug_toggle");
+const debugArea = document.getElementById("debug_area");
+const debugLog = document.getElementById("debug_log");
+const debugDecoded = document.getElementById("debug_decoded");
+const debugIssueToken = document.getElementById("debug_issue_token");
+const debugCookies = document.getElementById("debug_cookies");
+
+let debugVisible = false;
+let debugInterval = null;
+
+function updateDecodedFields() {
+  if (!debugVisible || !authCodeField.value) {
+    debugDecoded.style.display = "none";
+    return;
+  }
+  try {
+    const decoded = JSON.parse(atob(authCodeField.value));
+    debugIssueToken.value = decoded.issue_token ?? "";
+    debugCookies.value = decoded.cookies ?? "";
+    debugDecoded.style.display = "block";
+  } catch (e) {
+    debugDecoded.style.display = "none";
+  }
+}
+
+function refreshLogs() {
+  browser.runtime.sendMessage({ action: "getLogs" }).then((r) => {
+    if (r?.logs?.length) {
+      debugLog.textContent = r.logs.join("\n");
+      debugArea.scrollTop = debugArea.scrollHeight;
+    }
+  });
+}
+
+debugToggle.addEventListener("click", () => {
+  debugVisible = !debugVisible;
+  debugArea.style.display = debugVisible ? "block" : "none";
+  debugToggle.textContent = (debugVisible ? "▼" : "▶") + " Debug logs";
+  if (debugVisible) {
+    refreshLogs();
+    debugInterval = setInterval(refreshLogs, 500);
+  } else {
+    clearInterval(debugInterval);
+    debugInterval = null;
+  }
+  updateDecodedFields();
+});
 
 let pollInterval = null;
 
@@ -13,7 +62,7 @@ function setStatus(msg, type) {
 function startPolling() {
   stopPolling();
   pollInterval = setInterval(() => {
-    chrome.runtime.sendMessage({ action: "getStatus" }, (r) => {
+    browser.runtime.sendMessage({ action: "getStatus" }).then((r) => {
       if (r && r.issueToken && r.cookies) {
         stopPolling();
         buildCode(r.issueToken, r.cookies);
@@ -38,6 +87,7 @@ function buildCode(issueToken, cookies) {
 
   authCodeField.value = code;
   outputArea.style.display = "block";
+  updateDecodedFields();
   extractBtn.disabled = false;
   extractBtn.textContent = "Extract Credentials";
   setStatus(
@@ -47,7 +97,7 @@ function buildCode(issueToken, cookies) {
 }
 
 // On popup open, check if already captured
-chrome.runtime.sendMessage({ action: "getStatus" }, (r) => {
+browser.runtime.sendMessage({ action: "getStatus" }).then((r) => {
   if (r && r.issueToken && r.cookies) {
     buildCode(r.issueToken, r.cookies);
   } else if (r && r.listening) {
@@ -66,14 +116,14 @@ extractBtn.addEventListener("click", () => {
   extractBtn.textContent = "Waiting...";
   outputArea.style.display = "none";
 
-  chrome.runtime.sendMessage({ action: "reset" }, () => {
-    chrome.runtime.sendMessage({ action: "startCapture" }, () => {
-      setStatus(
-        "Opening home.nest.com... Sign in if needed. Credentials will be captured automatically.",
-        "info"
-      );
-      startPolling();
-    });
+  browser.runtime.sendMessage({ action: "reset" }).then(() => {
+    return browser.runtime.sendMessage({ action: "startCapture" });
+  }).then(() => {
+    setStatus(
+      "Opening home.nest.com... Sign in if needed. Credentials will be captured automatically.",
+      "info"
+    );
+    startPolling();
   });
 });
 


### PR DESCRIPTION
- **Firefox compatibility**: add `background.scripts` to manifest (Firefox MV3 doesn't support `service_worker`), add gecko `browser_specific_settings`, replace hardcoded `chrome.*` API with a cross-browser `browser` shim
- **Fix Chrome capture**: use `browser.runtime.getBrowserInfo` (Firefox-only API) to reliably detect Firefox and pass `extraHeaders` conditionally — Chrome 120+ exposes `globalThis.browser` as an alias for `chrome`, making naive `typeof browser` checks unreliable; fix cookie fallback: `FIRST_PARTY_AUTH_COOKIES` filter was excluding modern Google cookie names (`__Secure-3PSID` etc.), now falls back to all `accounts.google.com` cookies when no Cookie header is present
- **Debug panel**: collapsible log panel in the popup to diagnose capture issues

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<img width="445" height="608" alt="image" src="https://github.com/user-attachments/assets/78b4016a-280b-40ef-98a1-ba652b055ae0" />