### PR TITLE
Fix auth failure counter not resetting after successful token refresh or timeout

### DIFF
--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -111,14 +111,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         raise ConfigEntryAuthFailed("No credentials available")
 
     # Update cookies in config entry if Google returned refreshed ones
-    if (
-        session_manager.refreshed_cookies
-        and session_manager.refreshed_cookies != cookies
-    ):
-        hass.config_entries.async_update_entry(
-            entry,
-            data={**entry.data, CONF_COOKIES: session_manager.refreshed_cookies},
-        )
+    _persist_refreshed_cookies(hass, entry, client, session_manager)
 
     device_buckets: list[Bucket] = []
     areas: dict[str, str] = {}
@@ -174,6 +167,31 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
         hass, STORAGE_VERSION, STORAGE_KEY_FORMAT.format(entry_id=entry.entry_id)
     )
     await store.async_remove()
+
+
+def _persist_refreshed_cookies(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    client: NestClient,
+    sm: NestSessionManager,
+) -> None:
+    """Persist Google-rotated cookies back to the config entry and client.
+
+    Google may rotate OAuth cookies during ``get_access_token_from_cookies``.
+    Without writing them back, a HA restart would use stale cookies and force
+    re-authentication; the in-memory client also needs the update so the next
+    refresh in the same HA session uses fresh cookies.
+    """
+    new_cookies = sm.refreshed_cookies
+    if not new_cookies or new_cookies == entry.data.get(CONF_COOKIES):
+        return
+
+    LOGGER.debug("Persisting refreshed Nest cookies")
+    hass.config_entries.async_update_entry(
+        entry,
+        data={**entry.data, CONF_COOKIES: new_cookies},
+    )
+    client.cookies = new_cookies
 
 
 def _register_subscribe_task(
@@ -266,6 +284,7 @@ async def _async_subscribe_for_data(
 
     except asyncio.exceptions.TimeoutError:
         LOGGER.debug("Subscriber: session timed out.")
+        sm.record_success()
         _register_subscribe_task(hass, entry, data)
 
     except ClientConnectorError:
@@ -300,6 +319,13 @@ async def _async_subscribe_for_data(
         await asyncio.sleep(sm.backoff_interval)
 
         await sm.async_refresh_session()
+
+        # Entry may have been unloaded during the backoff sleep
+        if entry.entry_id not in hass.data.get(DOMAIN, {}):
+            return
+
+        _persist_refreshed_cookies(hass, entry, entry_data.client, sm)
+
         _register_subscribe_task(hass, entry, data)
 
     except BadCredentialsException:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,16 +1,23 @@
 """Test init."""
 
 import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
 from homeassistant.config_entries import ConfigEntryState
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.nest_protect import (
+    DOMAIN,
+    HomeAssistantNestProtectData,
+    _async_subscribe_for_data,
+)
+from custom_components.nest_protect.const import CONF_COOKIES, MAX_AUTH_FAILURES
 from custom_components.nest_protect.pynest.exceptions import NotAuthenticatedException
+from custom_components.nest_protect.session import NestSessionManager
 
-from .conftest import ComponentSetup
+from .conftest import COOKIES, ISSUE_TOKEN, ComponentSetup
 
 
 @pytest.mark.skip(
@@ -294,3 +301,157 @@ async def test_startup_falls_through_on_401_from_persisted_session(
 
     mock_cookie_auth.assert_called_once()
     assert config_entry_with_cookies.state is ConfigEntryState.LOADED
+
+
+def _make_subscriber_entry_data(
+    hass, entry, consecutive_failures=0, refreshed_cookies=None
+):
+    """Build minimal HomeAssistantNestProtectData for subscriber tests."""
+    client = MagicMock()
+    client.nest_session = MagicMock(is_expired=lambda buffer_seconds=0: False)
+    client.refreshed_cookies = refreshed_cookies
+
+    store = MagicMock()
+    store.async_load = AsyncMock(return_value=None)
+    sm = NestSessionManager(client, store)
+    sm._consecutive_failures = consecutive_failures
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = HomeAssistantNestProtectData(
+        devices={}, areas={}, client=client, session_manager=sm
+    )
+    return client, sm
+
+
+def _make_subscribe_data():
+    data = MagicMock()
+    data.service_urls = {"urls": {"transport_url": "https://t.example.com"}}
+    data.updated_buckets = []
+    return data
+
+
+async def test_subscriber_timeout_resets_failure_counter(hass):
+    """TimeoutError resets failure counter — it's not an auth failure."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "issue_token": ISSUE_TOKEN,
+            "cookies": COOKIES,
+            "account_type": "production",
+        },
+    )
+    entry.add_to_hass(hass)
+    client, sm = _make_subscriber_entry_data(hass, entry, consecutive_failures=2)
+    client.subscribe_for_data = AsyncMock(side_effect=TimeoutError())
+
+    with (
+        patch("custom_components.nest_protect._register_subscribe_task"),
+        patch.object(sm, "ensure_session", new_callable=AsyncMock),
+    ):
+        await _async_subscribe_for_data(hass, entry, _make_subscribe_data())
+
+    assert sm.consecutive_failures == 0
+
+
+async def test_subscriber_401_accumulates_failure_counter(hass):
+    """401 path must not reset the counter — repeated 401s should reach MAX_AUTH_FAILURES."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "issue_token": ISSUE_TOKEN,
+            "cookies": COOKIES,
+            "account_type": "production",
+        },
+    )
+    entry.add_to_hass(hass)
+    client, sm = _make_subscriber_entry_data(hass, entry, consecutive_failures=0)
+    client.subscribe_for_data = AsyncMock(side_effect=NotAuthenticatedException())
+
+    with (
+        patch("custom_components.nest_protect._register_subscribe_task"),
+        patch.object(sm, "ensure_session", new_callable=AsyncMock),
+        patch.object(sm, "async_refresh_session", new_callable=AsyncMock),
+        patch("custom_components.nest_protect.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await _async_subscribe_for_data(hass, entry, _make_subscribe_data())
+
+    assert sm.consecutive_failures == 1
+
+
+async def test_subscriber_401_persists_refreshed_cookies(hass):
+    """401 path persists refreshed cookies into the config entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "issue_token": ISSUE_TOKEN,
+            "cookies": COOKIES,
+            "account_type": "production",
+        },
+    )
+    entry.add_to_hass(hass)
+    new_cookies = "SID=new-sid; HSID=new-hsid"
+    client, sm = _make_subscriber_entry_data(hass, entry, refreshed_cookies=new_cookies)
+    client.subscribe_for_data = AsyncMock(side_effect=NotAuthenticatedException())
+
+    with (
+        patch("custom_components.nest_protect._register_subscribe_task"),
+        patch.object(sm, "ensure_session", new_callable=AsyncMock),
+        patch.object(sm, "async_refresh_session", new_callable=AsyncMock),
+        patch("custom_components.nest_protect.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await _async_subscribe_for_data(hass, entry, _make_subscribe_data())
+
+    assert entry.data.get(CONF_COOKIES) == new_cookies
+    # In-memory client must also be updated so the next refresh in this HA
+    # session uses fresh cookies (regression guard for bc05166).
+    assert client.cookies == new_cookies
+
+
+async def test_subscriber_401_repeated_failures_triggers_reauth(hass):
+    """Repeated 401s should reach MAX_AUTH_FAILURES and trigger reauth."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "issue_token": ISSUE_TOKEN,
+            "cookies": COOKIES,
+            "account_type": "production",
+        },
+    )
+    entry.add_to_hass(hass)
+    client, sm = _make_subscriber_entry_data(hass, entry, consecutive_failures=0)
+    client.subscribe_for_data = AsyncMock(side_effect=NotAuthenticatedException())
+
+    with (
+        patch("custom_components.nest_protect._register_subscribe_task"),
+        patch.object(sm, "ensure_session", new_callable=AsyncMock),
+        patch.object(sm, "async_refresh_session", new_callable=AsyncMock),
+        patch("custom_components.nest_protect.asyncio.sleep", new_callable=AsyncMock),
+        patch.object(entry, "async_start_reauth") as mock_reauth,
+    ):
+        for _ in range(MAX_AUTH_FAILURES):
+            await _async_subscribe_for_data(hass, entry, _make_subscribe_data())
+
+    assert sm.consecutive_failures == MAX_AUTH_FAILURES
+    mock_reauth.assert_called_once_with(hass)
+
+
+async def test_subscriber_success_resets_failure_counter(hass):
+    """A successful subscribe call must reset the failure counter to zero."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "issue_token": ISSUE_TOKEN,
+            "cookies": COOKIES,
+            "account_type": "production",
+        },
+    )
+    entry.add_to_hass(hass)
+    client, sm = _make_subscriber_entry_data(hass, entry, consecutive_failures=2)
+    client.subscribe_for_data = AsyncMock(return_value={"objects": []})
+
+    with (
+        patch("custom_components.nest_protect._register_subscribe_task"),
+        patch.object(sm, "ensure_session", new_callable=AsyncMock),
+    ):
+        await _async_subscribe_for_data(hass, entry, _make_subscribe_data())
+
+    assert sm.consecutive_failures == 0


### PR DESCRIPTION
Should solve https://github.com/iMicknl/ha-nest-protect/issues/481 

Been running this fix locally for a while and it's been working without issue.