### PR TITLE
Fix KeyError crash in generate_device_info() for Topaz devices with incomplete API data

### DIFF
--- a/custom_components/nest_protect/entity.py
+++ b/custom_components/nest_protect/entity.py
@@ -53,22 +53,52 @@ class NestEntity(Entity):
         label = self._device_label()
 
         if self.bucket.object_key.startswith("topaz."):
+            connections = set()
+            mac = self.bucket.value.get("wifi_mac_address")
+            if mac:
+                connections.add((dr.CONNECTION_NETWORK_MAC, mac))
+
+            identifier = (
+                self.bucket.value.get("serial_number") or self.bucket.object_key
+            )
+
+            structure_id = self.bucket.value.get("structure_id")
+            device_id = self.bucket.object_key.removeprefix("topaz.")
+
             return DeviceInfo(
-                connections={
-                    (dr.CONNECTION_NETWORK_MAC, self.bucket.value["wifi_mac_address"])
-                },
-                identifiers={(DOMAIN, self.bucket.value["serial_number"])},
+                connections=connections,
+                identifiers={(DOMAIN, identifier)},
                 name=f"Nest Protect ({label})" if label else "Nest Protect",
                 manufacturer="Google",
-                model=self.bucket.value["model"],
-                sw_version=self.bucket.value["software_version"],
+                model=self.bucket.value.get("model"),
+                sw_version=self.bucket.value.get("software_version"),
                 hw_version=(
-                    "Wired" if self.bucket.value["wired_or_battery"] == 0 else "Battery"
+                    "Wired" if self.bucket.value.get("wired_or_battery") == 0 else "Battery"
                 ),
                 suggested_area=self.area,
-                configuration_url="https://home.nest.com/protect/"
-                + self.bucket.value["structure_id"],  # TODO change url based on device
+                configuration_url=(
+                    f"https://home.nest.com/protect/{structure_id}/settings/device/{device_id}#about"
+                    if structure_id
+                    else None
+                ),
             )
+
+        if self.bucket.object_key.startswith("kryptonite."):
+            identifier = (
+                self.bucket.value.get("serial_number") or self.bucket.object_key
+            )
+
+            return DeviceInfo(
+                identifiers={(DOMAIN, identifier)},
+                name=f"Nest Temperature Sensor ({label})"
+                if label
+                else "Nest Temperature Sensor",
+                manufacturer="Google",
+                model=self.bucket.value.get("model"),
+                suggested_area=self.area,
+            )
+
+        return None
 
         if self.bucket.object_key.startswith("kryptonite."):
             identifier = (

--- a/custom_components/nest_protect/entity.py
+++ b/custom_components/nest_protect/entity.py
@@ -73,7 +73,9 @@ class NestEntity(Entity):
                 model=self.bucket.value.get("model"),
                 sw_version=self.bucket.value.get("software_version"),
                 hw_version=(
-                    "Wired" if self.bucket.value.get("wired_or_battery") == 0 else "Battery"
+                    "Wired"
+                    if self.bucket.value.get("wired_or_battery") == 0
+                    else "Battery"
                 ),
                 suggested_area=self.area,
                 configuration_url=(

--- a/custom_components/nest_protect/entity.py
+++ b/custom_components/nest_protect/entity.py
@@ -100,8 +100,6 @@ class NestEntity(Entity):
                 suggested_area=self.area,
             )
 
-        return None
-
         if self.bucket.object_key.startswith("kryptonite."):
             identifier = (
                 self.bucket.value.get("serial_number") or self.bucket.object_key

--- a/custom_components/nest_protect/entity.py
+++ b/custom_components/nest_protect/entity.py
@@ -100,21 +100,6 @@ class NestEntity(Entity):
                 suggested_area=self.area,
             )
 
-        if self.bucket.object_key.startswith("kryptonite."):
-            identifier = (
-                self.bucket.value.get("serial_number") or self.bucket.object_key
-            )
-
-            return DeviceInfo(
-                identifiers={(DOMAIN, identifier)},
-                name=f"Nest Temperature Sensor ({label})"
-                if label
-                else "Nest Temperature Sensor",
-                manufacturer="Google",
-                model=self.bucket.value.get("model"),
-                suggested_area=self.area,
-            )
-
         return None
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/nest_protect/entity.py
+++ b/custom_components/nest_protect/entity.py
@@ -65,6 +65,13 @@ class NestEntity(Entity):
             structure_id = self.bucket.value.get("structure_id")
             device_id = self.bucket.object_key.removeprefix("topaz.")
 
+            # Absent means unknown, not battery-powered
+            wired_or_battery = self.bucket.value.get("wired_or_battery")
+            if wired_or_battery is None:
+                hw_version = None
+            else:
+                hw_version = "Wired" if wired_or_battery == 0 else "Battery"
+
             return DeviceInfo(
                 connections=connections,
                 identifiers={(DOMAIN, identifier)},
@@ -72,11 +79,7 @@ class NestEntity(Entity):
                 manufacturer="Google",
                 model=self.bucket.value.get("model"),
                 sw_version=self.bucket.value.get("software_version"),
-                hw_version=(
-                    "Wired"
-                    if self.bucket.value.get("wired_or_battery") == 0
-                    else "Battery"
-                ),
+                hw_version=hw_version,
                 suggested_area=self.area,
                 configuration_url=(
                     f"https://home.nest.com/protect/{structure_id}/settings/device/{device_id}#about"

--- a/custom_components/nest_protect/entity.py
+++ b/custom_components/nest_protect/entity.py
@@ -34,7 +34,7 @@ class NestEntity(Entity):
         self.entity_description = description
         self.bucket = bucket
         self.client = client
-        self.area = areas.get(self.bucket.value["where_id"])
+        self.area = areas.get(self.bucket.value.get("where_id"))
 
         self._attr_unique_id = bucket.object_key
         self._attr_attribution = ATTRIBUTION

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,0 +1,128 @@
+"""Tests for the Nest Protect entity base class."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.entity import EntityDescription
+
+from custom_components.nest_protect.const import DOMAIN
+from custom_components.nest_protect.entity import NestEntity
+from custom_components.nest_protect.pynest.models import Bucket
+
+AREAS = {"where.living-room": "Living Room"}
+
+# Topaz-2.0 revisions omit wifi_mac_address, serial_number and software_version
+MINIMAL_TOPAZ = {"where_id": "where.living-room"}
+
+COMPLETE_TOPAZ = {
+    "where_id": "where.living-room",
+    "wifi_mac_address": "AA:BB:CC:DD:EE:FF",
+    "serial_number": "ABC123",
+    "model": "Topaz-2.9",
+    "software_version": "3.5.0",
+    "wired_or_battery": 1,
+    "structure_id": "structure.4321",
+}
+
+
+def build_entity(value: dict, object_key: str = "topaz.1234") -> NestEntity:
+    """Build a NestEntity from a raw bucket value."""
+    bucket = Bucket(
+        object_key=object_key,
+        object_revision=1,
+        object_timestamp=1,
+        value=value,
+    )
+    return NestEntity(
+        bucket=bucket,
+        description=EntityDescription(key="test"),
+        areas=AREAS,
+        client=MagicMock(),
+    )
+
+
+def test_complete_topaz_device_info():
+    """Test that a fully populated Topaz reports every field."""
+    device_info = build_entity(COMPLETE_TOPAZ).device_info
+
+    assert device_info["connections"] == {
+        (dr.CONNECTION_NETWORK_MAC, "AA:BB:CC:DD:EE:FF")
+    }
+    assert device_info["identifiers"] == {(DOMAIN, "ABC123")}
+    assert device_info["name"] == "Nest Protect (Living Room)"
+    assert device_info["model"] == "Topaz-2.9"
+    assert device_info["sw_version"] == "3.5.0"
+    assert device_info["hw_version"] == "Battery"
+    assert device_info["suggested_area"] == "Living Room"
+    assert device_info["configuration_url"] == (
+        "https://home.nest.com/protect/structure.4321/settings/device/1234#about"
+    )
+
+
+def test_incomplete_topaz_does_not_raise():
+    """Test that a Topaz missing optional fields still produces device info."""
+    device_info = build_entity(MINIMAL_TOPAZ).device_info
+
+    assert device_info is not None
+    # No MAC means no connection, rather than a connection to None
+    assert device_info["connections"] == set()
+    assert device_info["identifiers"] == {(DOMAIN, "topaz.1234")}
+    assert device_info["name"] == "Nest Protect (Living Room)"
+    assert device_info["model"] is None
+    assert device_info["sw_version"] is None
+    assert device_info["configuration_url"] is None
+
+
+def test_incomplete_topaz_power_source_is_unknown():
+    """Test that an absent wired_or_battery is not reported as Battery."""
+    assert build_entity(MINIMAL_TOPAZ).device_info["hw_version"] is None
+
+
+@pytest.mark.parametrize(
+    ("wired_or_battery", "expected"),
+    [(0, "Wired"), (1, "Battery")],
+)
+def test_topaz_power_source(wired_or_battery: int, expected: str):
+    """Test that a known wired_or_battery maps to a hardware version."""
+    entity = build_entity(MINIMAL_TOPAZ | {"wired_or_battery": wired_or_battery})
+    assert entity.device_info["hw_version"] == expected
+
+
+def test_missing_where_id_does_not_raise():
+    """Test that a payload without where_id still sets up."""
+    entity = build_entity({})
+
+    assert entity.area is None
+    assert entity.device_info["name"] == "Nest Protect"
+    assert entity.device_info["suggested_area"] is None
+
+
+def test_description_takes_precedence_over_area():
+    """Test that the device description is preferred as a label."""
+    entity = build_entity(MINIMAL_TOPAZ | {"description": "Hallway"})
+    assert entity.device_info["name"] == "Nest Protect (Hallway)"
+
+
+def test_kryptonite_device_info():
+    """Test that a temperature sensor reports its own device info."""
+    device_info = build_entity(
+        {
+            "where_id": "where.living-room",
+            "serial_number": "XYZ789",
+            "model": "Kryp-1.0",
+        },
+        object_key="kryptonite.5678",
+    ).device_info
+
+    assert device_info["identifiers"] == {(DOMAIN, "XYZ789")}
+    assert device_info["name"] == "Nest Temperature Sensor (Living Room)"
+    assert device_info["model"] == "Kryp-1.0"
+
+
+def test_incomplete_kryptonite_falls_back_to_object_key():
+    """Test that a temperature sensor without a serial number still sets up."""
+    device_info = build_entity({}, object_key="kryptonite.5678").device_info
+
+    assert device_info["identifiers"] == {(DOMAIN, "kryptonite.5678")}
+    assert device_info["name"] == "Nest Temperature Sensor"


### PR DESCRIPTION
Fixes #533
Related to #455

## Problem
Related to #455, which was closed as a one-off "provisioning problem" (missing MAC in the Google app). That may explain why the field is absent for some devices, but the actual bug is independent of the cause: any missing field in `self.bucket.value` currently crashes the *entire* entity setup for that device, silently, because `generate_device_info()` is shared across all platforms. This reproduces reliably for older Topaz hardware revisions (see Model below), not just isolated provisioning glitches.

`generate_device_info()` accessed `wifi_mac_address` and `serial_number` directly via `[...]`. Some Topaz (Nest Protect) hardware/firmware revisions (confirmed: Model `Topaz-2.0`, verified missing even in Google's own Nest dashboard, not just this integration) don't include these fields in their API payload. Because this method runs for every entity on every platform, the missing key crashed platform setup entirely, silently resulting in zero entities for the affected integration.

## Fix
Switch the `topaz.` branch to `.get(...)` with safe fallbacks, mirroring the existing pattern already used a few lines below in the `kryptonite.` branch. Device identifier now falls back to `self.bucket.object_key`, which is always present.

## Testing
Tested locally with a mixed setup of 3 Protects (two Topaz-2.9 with full data, one Topaz-2.0 missing wifi_mac_address/serial_number/software_version). Before: zero entities for any device. After: all entities load correctly; the Topaz-2.0 device simply has fewer diagnostic attributes populated (no Wi-Fi MAC connection, model/software shown as unknown where absent).

## Bonus fix
Also resolved the `# TODO change url based on device` comment: `configuration_url` now links directly to the specific device's settings page (`/protect/{structure_id}/settings/device/{device_id}#about`) instead of just the structure overview page. `device_id` is the `object_key` with the `topaz.` prefix stripped (e.g. `topaz.1234` → `1234`).