### PR TITLE
Add support for Home/Away. Migrate to protobuf and http2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,7 +143,8 @@ celerybeat.pid
 
 # Environments
 .env
-.venv
+.venv/
+.uv-cache/
 env/
 venv/
 ENV/

--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -47,6 +47,7 @@ from .pynest.models import (
     TopazBucket,
     WhereBucketValue,
 )
+from .pynest.protobuf import ProtobufDeviceUpdate, ProtobufStructureUpdate
 from .session import NestSessionManager
 
 
@@ -55,10 +56,13 @@ class HomeAssistantNestProtectData:
     """Nest Protect data stored in the Home Assistant data object."""
 
     devices: dict[str, Bucket]
+    structures: dict[str, Bucket]
     areas: dict[str, str]
     client: NestClient
     session_manager: NestSessionManager
     subscription_task: asyncio.Task | None = None
+    protobuf_observe_task: asyncio.Task | None = None
+    protobuf_structure_map: dict[str, str] | None = None
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
@@ -114,11 +118,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     _persist_refreshed_cookies(hass, entry, client, session_manager)
 
     device_buckets: list[Bucket] = []
+    structure_buckets: list[Bucket] = []
     areas: dict[str, str] = {}
 
     for bucket in data.updated_buckets:
         if bucket.type in {BucketType.TOPAZ, BucketType.KRYPTONITE}:
             device_buckets.append(bucket)
+
+        if bucket.type == BucketType.STRUCTURE:
+            structure_buckets.append(bucket)
 
         if bucket.type == BucketType.WHERE and isinstance(
             bucket.value, WhereBucketValue
@@ -128,9 +136,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 areas[area.where_id] = area.name
 
     devices: dict[str, Bucket] = {b.object_key: b for b in device_buckets}
+    structures: dict[str, Bucket] = {b.object_key: b for b in structure_buckets}
 
     entry_data = HomeAssistantNestProtectData(
         devices=devices,
+        structures=structures,
         areas=areas,
         client=client,
         session_manager=session_manager,
@@ -141,6 +151,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     entry_data.subscription_task = asyncio.create_task(
         _async_subscribe_for_data(hass, entry, data)
+    )
+    entry_data.protobuf_observe_task = asyncio.create_task(
+        _async_observe_for_protobuf_data(hass, entry)
     )
 
     return True
@@ -156,6 +169,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 entry_data.subscription_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await entry_data.subscription_task
+            if entry_data.protobuf_observe_task:
+                entry_data.protobuf_observe_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await entry_data.protobuf_observe_task
             hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
@@ -208,6 +225,125 @@ def _register_subscribe_task(
     return task
 
 
+async def _async_observe_for_protobuf_data(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> None:
+    """Observe protobuf data used by Home/Away on migrated Nest accounts."""
+    while entry.entry_id in hass.data.get(DOMAIN, {}):
+        entry_data: HomeAssistantNestProtectData = hass.data[DOMAIN][entry.entry_id]
+        sm = entry_data.session_manager
+
+        try:
+            await sm.ensure_session()
+
+            async for update in entry_data.client.observe_for_structure_updates(
+                entry_data.client.nest_session.access_token,
+            ):
+                if isinstance(update, ProtobufStructureUpdate):
+                    _apply_protobuf_structure_update(hass, entry_data, update)
+                else:
+                    _apply_protobuf_device_update(hass, entry_data, update)
+
+            LOGGER.debug("Protobuf observe stream ended.")
+            await asyncio.sleep(5)
+
+        except NotAuthenticatedException:
+            LOGGER.debug("Protobuf observe: 401 exception.")
+            sm.record_failure()
+
+            if sm.should_trigger_reauth:
+                LOGGER.warning(
+                    "Protobuf observe: %d consecutive auth failures, triggering re-authentication",
+                    sm.consecutive_failures,
+                )
+                entry.async_start_reauth(hass)
+                return
+
+            await asyncio.sleep(sm.backoff_interval)
+            await sm.async_refresh_session()
+
+        except BadCredentialsException:
+            LOGGER.warning(
+                "Bad credentials detected. Please re-authenticate the Nest Protect integration."
+            )
+            entry.async_start_reauth(hass)
+            return
+
+        except asyncio.CancelledError:
+            LOGGER.debug("Protobuf observe: task cancelled, stopping.")
+            raise
+
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception(
+                "Protobuf observe failed. Updates paused for %ds.",
+                sm.backoff_interval,
+            )
+            await asyncio.sleep(sm.backoff_interval)
+
+
+def _apply_protobuf_structure_update(
+    hass: HomeAssistant,
+    entry_data: HomeAssistantNestProtectData,
+    update: ProtobufStructureUpdate,
+) -> None:
+    """Merge a protobuf structure update into the legacy structure bucket."""
+    if entry_data.protobuf_structure_map is None:
+        entry_data.protobuf_structure_map = {}
+
+    if update.legacy_structure_id:
+        entry_data.protobuf_structure_map[update.resource_id] = update.legacy_structure_id
+
+    legacy_structure_id = update.legacy_structure_id or entry_data.protobuf_structure_map.get(
+        update.resource_id
+    )
+    if not legacy_structure_id:
+        LOGGER.debug(
+            "Protobuf observe: no legacy structure mapping for %s", update.resource_id
+        )
+        return
+
+    key = f"structure.{legacy_structure_id}"
+    structure = entry_data.structures.get(key)
+    if not structure:
+        LOGGER.debug("Protobuf observe: unknown legacy structure %s", key)
+        return
+
+    structure.value["new_structure_id"] = update.resource_id.removeprefix("STRUCTURE_")
+    structure.value["using_protobuf"] = True
+    if update.user_id:
+        structure.value["user_id"] = update.user_id
+    if update.away is not None:
+        structure.value["away"] = update.away
+        structure.value["protobuf_away"] = update.away
+
+    LOGGER.debug(
+        "Protobuf observe: updated structure %s with %s",
+        key,
+        sorted(k for k in ("new_structure_id", "user_id", "away") if k in structure.value),
+    )
+    async_dispatcher_send(hass, key, structure)
+
+
+def _apply_protobuf_device_update(
+    hass: HomeAssistant,
+    entry_data: HomeAssistantNestProtectData,
+    update: ProtobufDeviceUpdate,
+) -> None:
+    """Merge a protobuf temperature sensor update into the device bucket."""
+    device = entry_data.devices.get(update.object_key)
+    if not device:
+        LOGGER.debug("Protobuf observe: unknown device %s", update.object_key)
+        return
+
+    device.value.update(update.value)
+    LOGGER.debug(
+        "Protobuf observe: updated device %s with %s",
+        update.object_key,
+        sorted(update.value),
+    )
+    async_dispatcher_send(hass, update.object_key, device)
+
+
 async def _async_subscribe_for_data(
     hass: HomeAssistant, entry: ConfigEntry, data: FirstDataAPIResponse
 ):
@@ -256,6 +392,13 @@ async def _async_subscribe_for_data(
                 entry_data.devices[key] = kryptonite
 
                 async_dispatcher_send(hass, key, kryptonite)
+
+            # Structures / Home-Away
+            if key.startswith("structure."):
+                structure = Bucket(**bucket)
+                entry_data.structures[key] = structure
+
+                async_dispatcher_send(hass, key, structure)
 
         # Update buckets with new data, to only receive new updates
         buckets = {d["object_key"]: d for d in result["objects"]}

--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -25,9 +25,11 @@ from .const import (
     CONF_COOKIES,
     CONF_ISSUE_TOKEN,
     CONF_REFRESH_TOKEN,
+    DEVICE_CACHE_SAVE_DELAY,
     DOMAIN,
     LOGGER,
     PLATFORMS,
+    STORAGE_KEY_DEVICES_FORMAT,
     STORAGE_KEY_FORMAT,
     STORAGE_VERSION,
 )
@@ -55,7 +57,9 @@ from .pynest.protobuf import ProtobufDeviceUpdate, ProtobufStructureUpdate
 from .session import NestSessionManager
 from .thermostat import (
     THERMOSTAT_BUCKET_PREFIX,
+    THERMOSTAT_CACHE_KEYS,
     is_discoverable_thermostat,
+    thermostat_cache_entry,
     thermostat_discovery_signal,
 )
 
@@ -77,6 +81,9 @@ class HomeAssistantNestProtectData:
     protobuf_structure_map: dict[str, str] | None = None
     # Thermostat bucket keys already announced to the sensor platform.
     protobuf_thermostats: set[str] = field(default_factory=set)
+    # Persists protobuf-only devices, so a reload doesn't have to wait for the
+    # observe stream before it can recreate their entities.
+    device_store: Store | None = None
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
@@ -159,8 +166,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         client=client,
         session_manager=session_manager,
         grpc_lock_client=GrpcLockClient(client),
+        device_store=Store(
+            hass,
+            STORAGE_VERSION,
+            STORAGE_KEY_DEVICES_FORMAT.format(entry_id=entry.entry_id),
+        ),
     )
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry_data
+
+    await _async_restore_protobuf_thermostats(entry_data)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -273,11 +287,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Clean up persisted session data when the config entry is removed."""
-    store = Store(
-        hass, STORAGE_VERSION, STORAGE_KEY_FORMAT.format(entry_id=entry.entry_id)
-    )
-    await store.async_remove()
+    """Clean up persisted session and device data when the entry is removed."""
+    for key_format in (STORAGE_KEY_FORMAT, STORAGE_KEY_DEVICES_FORMAT):
+        store = Store(hass, STORAGE_VERSION, key_format.format(entry_id=entry.entry_id))
+        await store.async_remove()
 
 
 def _persist_refreshed_cookies(
@@ -423,6 +436,61 @@ def _apply_protobuf_structure_update(
     async_dispatcher_send(hass, key, structure)
 
 
+async def _async_restore_protobuf_thermostats(
+    entry_data: HomeAssistantNestProtectData,
+) -> None:
+    """Recreate thermostat buckets cached by a previous run.
+
+    Thermostats exist only on the protobuf stream, so without this the sensor
+    platform has nothing to add at setup: Home Assistant remembers the entities
+    from the registry and shows them as unavailable until the stream reconnects
+    and republishes every trait.
+    """
+    if entry_data.device_store is None:
+        return
+
+    cached = await entry_data.device_store.async_load()
+
+    for object_key, value in (cached or {}).items():
+        if not object_key.startswith(THERMOSTAT_BUCKET_PREFIX):
+            continue
+
+        bucket = Bucket(
+            object_key=object_key,
+            object_revision=0,
+            object_timestamp=0,
+            value=dict(value),
+        )
+        if not is_discoverable_thermostat(bucket):
+            continue
+
+        entry_data.devices[object_key] = bucket
+        # Already known to the platform, so later trait updates go straight to
+        # the per-bucket signal instead of announcing a second discovery.
+        entry_data.protobuf_thermostats.add(object_key)
+
+    if entry_data.protobuf_thermostats:
+        LOGGER.debug(
+            "Restored cached thermostats: %s",
+            sorted(entry_data.protobuf_thermostats),
+        )
+
+
+def _save_protobuf_thermostats(entry_data: HomeAssistantNestProtectData) -> None:
+    """Persist thermostat identity, debounced past the initial trait burst."""
+    if entry_data.device_store is None:
+        return
+
+    entry_data.device_store.async_delay_save(
+        lambda: {
+            object_key: thermostat_cache_entry(bucket)
+            for object_key, bucket in entry_data.devices.items()
+            if object_key.startswith(THERMOSTAT_BUCKET_PREFIX)
+        },
+        DEVICE_CACHE_SAVE_DELAY,
+    )
+
+
 def _apply_protobuf_device_update(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -460,6 +528,9 @@ def _apply_protobuf_device_update(
         )
 
     if update.object_key.startswith(THERMOSTAT_BUCKET_PREFIX):
+        if not THERMOSTAT_CACHE_KEYS.isdisjoint(update.value):
+            _save_protobuf_thermostats(entry_data)
+
         if update.object_key in entry_data.protobuf_thermostats:
             async_dispatcher_send(hass, update.object_key, device)
         elif is_discoverable_thermostat(device):

--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 from dataclasses import dataclass, field
 
+import httpx
 from aiohttp import (
     ClientConnectorError,
     ClientError,
@@ -29,6 +30,9 @@ from .const import (
     DOMAIN,
     LOGGER,
     PLATFORMS,
+    PROTOBUF_RECONNECT_INITIAL_DELAY,
+    PROTOBUF_RECONNECT_MAX_DELAY,
+    PROTOBUF_STREAM_HEALTHY_SECONDS,
     STORAGE_KEY_DEVICES_FORMAT,
     STORAGE_KEY_FORMAT,
     STORAGE_VERSION,
@@ -53,7 +57,11 @@ from .pynest.models import (
     TopazBucket,
     WhereBucketValue,
 )
-from .pynest.protobuf import ProtobufDeviceUpdate, ProtobufStructureUpdate
+from .pynest.protobuf import (
+    NEST_KRYPTONITE_RESOURCE,
+    ProtobufDeviceUpdate,
+    ProtobufStructureUpdate,
+)
 from .session import NestSessionManager
 from .thermostat import (
     THERMOSTAT_BUCKET_PREFIX,
@@ -175,6 +183,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry_data
 
     await _async_restore_protobuf_thermostats(entry_data)
+    _seed_protobuf_observe_state(entry_data)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -332,13 +341,29 @@ def _register_subscribe_task(
     return task
 
 
+def _next_observe_delay(delay: int, stream_duration: float) -> int:
+    """Pace the next observe reconnect.
+
+    A stream that stayed up long enough to be doing its job resets the delay;
+    anything shorter doubles it, so an account the gateway keeps hanging up on
+    settles into a slow retry instead of hammering it for weeks.
+    """
+    if stream_duration >= PROTOBUF_STREAM_HEALTHY_SECONDS:
+        return PROTOBUF_RECONNECT_INITIAL_DELAY
+    return min(delay * 2, PROTOBUF_RECONNECT_MAX_DELAY)
+
+
 async def _async_observe_for_protobuf_data(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> None:
-    """Observe protobuf data used by Home/Away on migrated Nest accounts."""
+    """Observe protobuf data: Home/Away, thermostats and temperature sensors."""
+    delay = PROTOBUF_RECONNECT_INITIAL_DELAY
+
     while entry.entry_id in hass.data.get(DOMAIN, {}):
         entry_data: HomeAssistantNestProtectData = hass.data[DOMAIN][entry.entry_id]
         sm = entry_data.session_manager
+        started = hass.loop.time()
+        received = False
 
         try:
             await sm.ensure_session()
@@ -346,13 +371,20 @@ async def _async_observe_for_protobuf_data(
             async for update in entry_data.client.observe_for_structure_updates(
                 entry_data.client.nest_session.access_token,
             ):
+                if not received:
+                    received = True
+                    # A stream that yields anything proves the shared session is
+                    # healthy, so clear failures recorded by any transport.
+                    sm.record_success()
+
                 if isinstance(update, ProtobufStructureUpdate):
                     _apply_protobuf_structure_update(hass, entry_data, update)
                 else:
                     _apply_protobuf_device_update(hass, entry, entry_data, update)
 
-            LOGGER.debug("Protobuf observe stream ended.")
-            await asyncio.sleep(5)
+            delay = _next_observe_delay(delay, hass.loop.time() - started)
+            LOGGER.debug("Protobuf observe stream ended. Reconnecting in %ds.", delay)
+            await asyncio.sleep(delay)
 
         except NotAuthenticatedException:
             LOGGER.debug("Protobuf observe: 401 exception.")
@@ -369,6 +401,12 @@ async def _async_observe_for_protobuf_data(
             await asyncio.sleep(sm.backoff_interval)
             await sm.async_refresh_session()
 
+            # Entry may have been unloaded during the backoff sleep
+            if entry.entry_id not in hass.data.get(DOMAIN, {}):
+                return
+
+            _persist_refreshed_cookies(hass, entry, entry_data.client, sm)
+
         except BadCredentialsException:
             LOGGER.warning(
                 "Bad credentials detected. Please re-authenticate the Nest Protect integration."
@@ -380,12 +418,22 @@ async def _async_observe_for_protobuf_data(
             LOGGER.debug("Protobuf observe: task cancelled, stopping.")
             raise
 
-        except Exception:  # pylint: disable=broad-except
-            LOGGER.exception(
-                "Protobuf observe failed. Updates paused for %ds.",
-                sm.backoff_interval,
+        except (httpx.HTTPError, TimeoutError, OSError) as err:
+            # Read timeouts, resets and gateway hiccups are routine on a stream
+            # that is meant to stay open for weeks. Logging a traceback for each
+            # would bury the failures that actually need attention.
+            delay = _next_observe_delay(delay, hass.loop.time() - started)
+            LOGGER.debug(
+                "Protobuf observe: transport error (%r). Reconnecting in %ds.",
+                err,
+                delay,
             )
-            await asyncio.sleep(sm.backoff_interval)
+            await asyncio.sleep(delay)
+
+        except Exception:  # pylint: disable=broad-except
+            delay = _next_observe_delay(delay, hass.loop.time() - started)
+            LOGGER.exception("Protobuf observe failed. Updates paused for %ds.", delay)
+            await asyncio.sleep(delay)
 
 
 def _apply_protobuf_structure_update(
@@ -474,6 +522,40 @@ async def _async_restore_protobuf_thermostats(
             "Restored cached thermostats: %s",
             sorted(entry_data.protobuf_thermostats),
         )
+
+
+def _seed_protobuf_observe_state(entry_data: HomeAssistantNestProtectData) -> None:
+    """Tell the observe decoder about devices we already know.
+
+    The decoder can only route a device trait once `PeerDevicesTrait` has told
+    it what type that device is, and the gateway gives no ordering guarantee
+    between the two. Everything already known from app_launch or the device
+    cache is therefore pushed in up front, so the first stream after a restart
+    doesn't have to win that race before it can accept a reading.
+    """
+    state = entry_data.client.protobuf_observe_state
+
+    for object_key, bucket in entry_data.devices.items():
+        device_id = bucket.value.get("device_id")
+        if not device_id:
+            # Legacy REST buckets are keyed `<type>.<device id>`.
+            _, _, device_id = object_key.partition(".")
+        if not device_id:
+            continue
+
+        if device_type := bucket.value.get("protobuf_device_type"):
+            state.device_types[device_id] = device_type
+        elif object_key.startswith("kryptonite."):
+            # A kryptonite bucket is a Nest Temperature Sensor by definition.
+            state.device_types[device_id] = NEST_KRYPTONITE_RESOURCE
+        elif object_key.startswith("topaz."):
+            # Protects are served over REST here; drop their protobuf traits on
+            # sight rather than holding them for a mapping that never comes.
+            state.unsupported_devices.add(device_id)
+
+    LOGGER.debug(
+        "Seeded observe decoder with %d known device(s)", len(state.device_types)
+    )
 
 
 def _save_protobuf_thermostats(entry_data: HomeAssistantNestProtectData) -> None:

--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -378,10 +378,13 @@ def _apply_protobuf_structure_update(
         entry_data.protobuf_structure_map = {}
 
     if update.legacy_structure_id:
-        entry_data.protobuf_structure_map[update.resource_id] = update.legacy_structure_id
+        entry_data.protobuf_structure_map[update.resource_id] = (
+            update.legacy_structure_id
+        )
 
-    legacy_structure_id = update.legacy_structure_id or entry_data.protobuf_structure_map.get(
-        update.resource_id
+    legacy_structure_id = (
+        update.legacy_structure_id
+        or entry_data.protobuf_structure_map.get(update.resource_id)
     )
     if not legacy_structure_id:
         LOGGER.debug(
@@ -406,7 +409,9 @@ def _apply_protobuf_structure_update(
     LOGGER.debug(
         "Protobuf observe: updated structure %s with %s",
         key,
-        sorted(k for k in ("new_structure_id", "user_id", "away") if k in structure.value),
+        sorted(
+            k for k in ("new_structure_id", "user_id", "away") if k in structure.value
+        ),
     )
     async_dispatcher_send(hass, key, structure)
 

--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -51,6 +51,7 @@ from .pynest.models import (
     TopazBucket,
     WhereBucketValue,
 )
+from .pynest.protobuf import ProtobufDeviceUpdate, ProtobufStructureUpdate
 from .session import NestSessionManager
 
 
@@ -59,6 +60,7 @@ class HomeAssistantNestProtectData:
     """Nest Protect data stored in the Home Assistant data object."""
 
     devices: dict[str, Bucket]
+    structures: dict[str, Bucket]
     areas: dict[str, str]
     client: NestClient
     session_manager: NestSessionManager
@@ -66,6 +68,8 @@ class HomeAssistantNestProtectData:
     subscription_task: asyncio.Task | None = None
     lock_observe_task: asyncio.Task | None = None
     lock_state_cache: dict[str, LockState] = field(default_factory=dict)
+    protobuf_observe_task: asyncio.Task | None = None
+    protobuf_structure_map: dict[str, str] | None = None
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
@@ -121,11 +125,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     _persist_refreshed_cookies(hass, entry, client, session_manager)
 
     device_buckets: list[Bucket] = []
+    structure_buckets: list[Bucket] = []
     areas: dict[str, str] = {}
 
     for bucket in data.updated_buckets:
         if bucket.type in {BucketType.TOPAZ, BucketType.KRYPTONITE}:
             device_buckets.append(bucket)
+
+        if bucket.type == BucketType.STRUCTURE:
+            structure_buckets.append(bucket)
 
         if bucket.type == BucketType.WHERE and isinstance(
             bucket.value, WhereBucketValue
@@ -135,9 +143,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 areas[area.where_id] = area.name
 
     devices: dict[str, Bucket] = {b.object_key: b for b in device_buckets}
+    structures: dict[str, Bucket] = {b.object_key: b for b in structure_buckets}
 
     entry_data = HomeAssistantNestProtectData(
         devices=devices,
+        structures=structures,
         areas=areas,
         client=client,
         session_manager=session_manager,
@@ -149,6 +159,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     entry_data.subscription_task = asyncio.create_task(
         _async_subscribe_for_data(hass, entry, data)
+    )
+    entry_data.protobuf_observe_task = asyncio.create_task(
+        _async_observe_for_protobuf_data(hass, entry)
     )
 
     entry_data.lock_observe_task = entry.async_create_background_task(
@@ -243,6 +256,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 entry_data.lock_observe_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await entry_data.lock_observe_task
+            if entry_data.protobuf_observe_task:
+                entry_data.protobuf_observe_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await entry_data.protobuf_observe_task
             hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
@@ -295,6 +312,125 @@ def _register_subscribe_task(
     return task
 
 
+async def _async_observe_for_protobuf_data(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> None:
+    """Observe protobuf data used by Home/Away on migrated Nest accounts."""
+    while entry.entry_id in hass.data.get(DOMAIN, {}):
+        entry_data: HomeAssistantNestProtectData = hass.data[DOMAIN][entry.entry_id]
+        sm = entry_data.session_manager
+
+        try:
+            await sm.ensure_session()
+
+            async for update in entry_data.client.observe_for_structure_updates(
+                entry_data.client.nest_session.access_token,
+            ):
+                if isinstance(update, ProtobufStructureUpdate):
+                    _apply_protobuf_structure_update(hass, entry_data, update)
+                else:
+                    _apply_protobuf_device_update(hass, entry_data, update)
+
+            LOGGER.debug("Protobuf observe stream ended.")
+            await asyncio.sleep(5)
+
+        except NotAuthenticatedException:
+            LOGGER.debug("Protobuf observe: 401 exception.")
+            sm.record_failure()
+
+            if sm.should_trigger_reauth:
+                LOGGER.warning(
+                    "Protobuf observe: %d consecutive auth failures, triggering re-authentication",
+                    sm.consecutive_failures,
+                )
+                entry.async_start_reauth(hass)
+                return
+
+            await asyncio.sleep(sm.backoff_interval)
+            await sm.async_refresh_session()
+
+        except BadCredentialsException:
+            LOGGER.warning(
+                "Bad credentials detected. Please re-authenticate the Nest Protect integration."
+            )
+            entry.async_start_reauth(hass)
+            return
+
+        except asyncio.CancelledError:
+            LOGGER.debug("Protobuf observe: task cancelled, stopping.")
+            raise
+
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception(
+                "Protobuf observe failed. Updates paused for %ds.",
+                sm.backoff_interval,
+            )
+            await asyncio.sleep(sm.backoff_interval)
+
+
+def _apply_protobuf_structure_update(
+    hass: HomeAssistant,
+    entry_data: HomeAssistantNestProtectData,
+    update: ProtobufStructureUpdate,
+) -> None:
+    """Merge a protobuf structure update into the legacy structure bucket."""
+    if entry_data.protobuf_structure_map is None:
+        entry_data.protobuf_structure_map = {}
+
+    if update.legacy_structure_id:
+        entry_data.protobuf_structure_map[update.resource_id] = update.legacy_structure_id
+
+    legacy_structure_id = update.legacy_structure_id or entry_data.protobuf_structure_map.get(
+        update.resource_id
+    )
+    if not legacy_structure_id:
+        LOGGER.debug(
+            "Protobuf observe: no legacy structure mapping for %s", update.resource_id
+        )
+        return
+
+    key = f"structure.{legacy_structure_id}"
+    structure = entry_data.structures.get(key)
+    if not structure:
+        LOGGER.debug("Protobuf observe: unknown legacy structure %s", key)
+        return
+
+    structure.value["new_structure_id"] = update.resource_id.removeprefix("STRUCTURE_")
+    structure.value["using_protobuf"] = True
+    if update.user_id:
+        structure.value["user_id"] = update.user_id
+    if update.away is not None:
+        structure.value["away"] = update.away
+        structure.value["protobuf_away"] = update.away
+
+    LOGGER.debug(
+        "Protobuf observe: updated structure %s with %s",
+        key,
+        sorted(k for k in ("new_structure_id", "user_id", "away") if k in structure.value),
+    )
+    async_dispatcher_send(hass, key, structure)
+
+
+def _apply_protobuf_device_update(
+    hass: HomeAssistant,
+    entry_data: HomeAssistantNestProtectData,
+    update: ProtobufDeviceUpdate,
+) -> None:
+    """Merge a protobuf temperature sensor update into the device bucket."""
+    device = entry_data.devices.get(update.object_key)
+    if not device:
+        LOGGER.debug("Protobuf observe: unknown device %s", update.object_key)
+        return
+
+    device.value.update(update.value)
+    LOGGER.debug(
+        "Protobuf observe: updated device %s with %s",
+        update.object_key,
+        sorted(update.value),
+    )
+    async_dispatcher_send(hass, update.object_key, device)
+
+
 async def _async_subscribe_for_data(
     hass: HomeAssistant, entry: ConfigEntry, data: FirstDataAPIResponse
 ):
@@ -344,6 +480,13 @@ async def _async_subscribe_for_data(
                 entry_data.devices[key] = kryptonite
 
                 async_dispatcher_send(hass, key, kryptonite)
+
+            # Structures / Home-Away
+            if key.startswith("structure."):
+                structure = Bucket(**bucket)
+                entry_data.structures[key] = structure
+
+                async_dispatcher_send(hass, key, structure)
 
         # Update buckets with new data, to only receive new updates
         buckets = {d["object_key"]: d for d in result["objects"]}

--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -53,6 +53,11 @@ from .pynest.models import (
 )
 from .pynest.protobuf import ProtobufDeviceUpdate, ProtobufStructureUpdate
 from .session import NestSessionManager
+from .thermostat import (
+    THERMOSTAT_BUCKET_PREFIX,
+    is_discoverable_thermostat,
+    thermostat_discovery_signal,
+)
 
 
 @dataclass
@@ -70,6 +75,8 @@ class HomeAssistantNestProtectData:
     lock_state_cache: dict[str, LockState] = field(default_factory=dict)
     protobuf_observe_task: asyncio.Task | None = None
     protobuf_structure_map: dict[str, str] | None = None
+    # Thermostat bucket keys already announced to the sensor platform.
+    protobuf_thermostats: set[str] = field(default_factory=set)
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
@@ -329,7 +336,7 @@ async def _async_observe_for_protobuf_data(
                 if isinstance(update, ProtobufStructureUpdate):
                     _apply_protobuf_structure_update(hass, entry_data, update)
                 else:
-                    _apply_protobuf_device_update(hass, entry_data, update)
+                    _apply_protobuf_device_update(hass, entry, entry_data, update)
 
             LOGGER.debug("Protobuf observe stream ended.")
             await asyncio.sleep(5)
@@ -418,21 +425,50 @@ def _apply_protobuf_structure_update(
 
 def _apply_protobuf_device_update(
     hass: HomeAssistant,
+    entry: ConfigEntry,
     entry_data: HomeAssistantNestProtectData,
     update: ProtobufDeviceUpdate,
 ) -> None:
-    """Merge a protobuf temperature sensor update into the device bucket."""
+    """Merge a protobuf device update into the matching device bucket."""
     device = entry_data.devices.get(update.object_key)
     if not device:
-        LOGGER.debug("Protobuf observe: unknown device %s", update.object_key)
+        # Thermostats have no legacy bucket to merge into, so the protobuf
+        # stream is the only place they exist. Everything else is expected to
+        # come from app_launch first.
+        if not update.object_key.startswith(THERMOSTAT_BUCKET_PREFIX):
+            LOGGER.debug("Protobuf observe: unknown device %s", update.object_key)
+            return
+
+        device = Bucket(
+            object_key=update.object_key,
+            object_revision=0,
+            object_timestamp=0,
+            value=dict(update.value),
+        )
+        entry_data.devices[update.object_key] = device
+        LOGGER.debug(
+            "Protobuf observe: discovered thermostat %s (%s)",
+            update.object_key,
+            update.value.get("protobuf_device_type"),
+        )
+    else:
+        device.value.update(update.value)
+        LOGGER.debug(
+            "Protobuf observe: updated device %s with %s",
+            update.object_key,
+            sorted(update.value),
+        )
+
+    if update.object_key.startswith(THERMOSTAT_BUCKET_PREFIX):
+        if update.object_key in entry_data.protobuf_thermostats:
+            async_dispatcher_send(hass, update.object_key, device)
+        elif is_discoverable_thermostat(device):
+            entry_data.protobuf_thermostats.add(update.object_key)
+            async_dispatcher_send(
+                hass, thermostat_discovery_signal(entry.entry_id), device
+            )
         return
 
-    device.value.update(update.value)
-    LOGGER.debug(
-        "Protobuf observe: updated device %s with %s",
-        update.object_key,
-        sorted(update.value),
-    )
     async_dispatcher_send(hass, update.object_key, device)
 
 

--- a/custom_components/nest_protect/const.py
+++ b/custom_components/nest_protect/const.py
@@ -28,6 +28,10 @@ PLATFORMS: list[Platform] = [
 
 STORAGE_VERSION: Final = 1
 STORAGE_KEY_FORMAT: Final = "nest_protect_{entry_id}"
+# Separate store: the session store is rewritten wholesale on every refresh.
+STORAGE_KEY_DEVICES_FORMAT: Final = "nest_protect_devices_{entry_id}"
+# Coalesce the burst of traits that arrives when the observe stream connects.
+DEVICE_CACHE_SAVE_DELAY: Final = 10
 SESSION_EXPIRY_BUFFER_SECONDS: Final = 300  # 5 minutes
 MAX_AUTH_FAILURES: Final = 3
 BACKOFF_INTERVALS: Final = (30, 60, 120, 300, 600)  # seconds, capped at 10 min

--- a/custom_components/nest_protect/const.py
+++ b/custom_components/nest_protect/const.py
@@ -33,5 +33,13 @@ STORAGE_KEY_DEVICES_FORMAT: Final = "nest_protect_devices_{entry_id}"
 # Coalesce the burst of traits that arrives when the observe stream connects.
 DEVICE_CACHE_SAVE_DELAY: Final = 10
 SESSION_EXPIRY_BUFFER_SECONDS: Final = 300  # 5 minutes
+# Reconnect pacing for the protobuf observe stream. The gateway hangs up on its
+# own schedule, so a fixed short delay would mean reconnecting every few
+# seconds for weeks on an account it doesn't want to keep a stream open for.
+PROTOBUF_RECONNECT_INITIAL_DELAY: Final = 5
+PROTOBUF_RECONNECT_MAX_DELAY: Final = 300
+# A stream that stayed up this long is treated as healthy, so the next
+# reconnect starts from the floor again instead of inheriting the backoff.
+PROTOBUF_STREAM_HEALTHY_SECONDS: Final = 60
 MAX_AUTH_FAILURES: Final = 3
 BACKOFF_INTERVALS: Final = (30, 60, 120, 300, 600)  # seconds, capped at 10 min

--- a/custom_components/nest_protect/entity.py
+++ b/custom_components/nest_protect/entity.py
@@ -88,6 +88,20 @@ class NestEntity(Entity):
                 ),
             )
 
+        if self.bucket.object_key.startswith("device."):
+            identifier = (
+                self.bucket.value.get("serial_number") or self.bucket.object_key
+            )
+
+            return DeviceInfo(
+                identifiers={(DOMAIN, identifier)},
+                name=f"Nest Thermostat ({label})" if label else "Nest Thermostat",
+                manufacturer="Google",
+                model=self.bucket.value.get("model"),
+                sw_version=self.bucket.value.get("current_version"),
+                suggested_area=self.area,
+            )
+
         if self.bucket.object_key.startswith("kryptonite."):
             identifier = (
                 self.bucket.value.get("serial_number") or self.bucket.object_key

--- a/custom_components/nest_protect/entity.py
+++ b/custom_components/nest_protect/entity.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
@@ -15,6 +15,19 @@ from .pynest.models import Bucket
 
 if TYPE_CHECKING:
     from .session import NestSessionManager
+
+
+def resolve_area(value: Any, areas: dict[str, str]) -> str | None:
+    """Resolve a bucket's room label.
+
+    `where_id` is the legacy where uuid the `where.` REST buckets are keyed by.
+    `where_label` is the literal room name published by the protobuf
+    `DeviceLocatedSettingsTrait`, and is the only source for devices that never
+    appear in a REST bucket, or whose room has no `where.` entry yet.
+    """
+    if not isinstance(value, dict):
+        return None
+    return areas.get(value.get("where_id")) or value.get("where_label")
 
 
 class NestEntity(Entity):
@@ -34,7 +47,7 @@ class NestEntity(Entity):
         self.entity_description = description
         self.bucket = bucket
         self.client = client
-        self.area = areas.get(self.bucket.value.get("where_id"))
+        self.area = resolve_area(self.bucket.value, areas)
 
         self._attr_unique_id = bucket.object_key
         self._attr_attribution = ATTRIBUTION

--- a/custom_components/nest_protect/manifest.json
+++ b/custom_components/nest_protect/manifest.json
@@ -13,6 +13,8 @@
   "documentation": "https://github.com/imicknl/ha-nest-protect",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/imicknl/ha-nest-protect/issues",
-  "requirements": [],
+  "requirements": [
+    "httpx[http2]>=0.28.1"
+  ],
   "version": "0.4.4b2"
 }

--- a/custom_components/nest_protect/manifest.json
+++ b/custom_components/nest_protect/manifest.json
@@ -13,6 +13,10 @@
   "documentation": "https://github.com/imicknl/ha-nest-protect",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/imicknl/ha-nest-protect/issues",
-  "requirements": ["protobuf>=6.31.1", "googleapis-common-protos>=1.56.0"],
+  "requirements": [
+    "protobuf>=6.31.1",
+    "googleapis-common-protos>=1.56.0",
+    "httpx[http2]>=0.28.1"
+  ],
   "version": "0.4.4b3"
 }

--- a/custom_components/nest_protect/pynest/client.py
+++ b/custom_components/nest_protect/pynest/client.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import AsyncIterator
 from random import randint
 from types import TracebackType
 from typing import Any, cast
+from uuid import uuid4
 
+import httpx
 from aiohttp import ClientSession, ClientTimeout, ContentTypeError, FormData
 
 from .const import (
@@ -15,6 +18,8 @@ from .const import (
     DEFAULT_NEST_ENVIRONMENT,
     NEST_AUTH_URL_JWT,
     NEST_REQUEST,
+    OBSERVE_PATH,
+    SEND_COMMAND_PATH,
     TOKEN_URL,
     USER_AGENT,
 )
@@ -35,6 +40,14 @@ from .models import (
     NestAuthResponse,
     NestEnvironment,
     NestResponse,
+)
+from .protobuf import (
+    ProtobufObserveState,
+    ProtobufObserveUpdate,
+    decode_observe_stream_frames,
+    decode_structure_updates,
+    encode_observe_request,
+    encode_structure_mode_resource_command_request,
 )
 
 _LOGGER = logging.getLogger(__package__)
@@ -408,3 +421,88 @@ class NestClient:
             # TODO type object
 
             return result
+
+    async def send_structure_mode_command(
+        self,
+        nest_access_token: str,
+        structure_resource_id: str,
+        user_id: str,
+        home: bool,
+    ) -> bytes:
+        """Send a protobuf structure Home/Away command."""
+        payload = encode_structure_mode_resource_command_request(
+            structure_resource_id=structure_resource_id,
+            user_id=user_id,
+            home=home,
+        )
+
+        timeout = httpx.Timeout(60.0, connect=30.0, write=30.0, pool=30.0)
+
+        async with httpx.AsyncClient(http2=True, timeout=timeout) as client:
+            response = await client.post(
+                self.environment.grpc_host + SEND_COMMAND_PATH,
+                content=payload,
+                headers={
+                    "Authorization": f"Basic {nest_access_token}",
+                    "Content-Type": "application/x-protobuf",
+                    "User-Agent": USER_AGENT,
+                    "X-Accept-Content-Transfer-Encoding": "binary",
+                    "X-Accept-Response-Streaming": "true",
+                },
+            )
+
+            if response.status_code == 401:
+                raise NotAuthenticatedException(await response.aread())
+
+            if response.status_code >= 400:
+                raise PynestException(
+                    f"{response.status_code} error while sending structure mode command - {await response.aread()}"
+                )
+
+            return await response.aread()
+
+    async def observe_for_structure_updates(
+        self,
+        nest_access_token: str,
+    ) -> AsyncIterator[ProtobufObserveUpdate]:
+        """Observe protobuf structure and temperature sensor updates."""
+        pending = b""
+        state = ProtobufObserveState()
+        headers = {
+            "Authorization": f"Basic {nest_access_token}",
+            "Content-Type": "application/x-protobuf",
+            "User-Agent": USER_AGENT,
+            "X-Accept-Content-Transfer-Encoding": "binary",
+            "X-Accept-Response-Streaming": "true",
+            "request-id": str(uuid4()),
+            "referer": self.environment.host + "/",
+            "origin": self.environment.host,
+            "x-nl-webapp-version": "NlAppSDKVersion/8.15.0 NlSchemaVersion/2.1.20-87-gce5742894",
+        }
+
+        timeout = httpx.Timeout(600.0, connect=30.0, write=30.0, pool=30.0)
+
+        async with (
+            httpx.AsyncClient(http2=True, timeout=timeout) as client,
+            client.stream(
+                "POST",
+                self.environment.grpc_host + OBSERVE_PATH,
+                headers=headers,
+                content=encode_observe_request(),
+            ) as response,
+        ):
+            if response.status_code == 401:
+                raise NotAuthenticatedException(await response.aread())
+
+            if response.status_code >= 400:
+                raise PynestException(
+                    f"{response.status_code} error while observing protobuf structure updates - {await response.aread()}"
+                )
+
+            async for chunk in response.aiter_bytes():
+                pending += chunk
+                frames, pending = decode_observe_stream_frames(pending)
+
+                for frame in frames:
+                    for update in decode_structure_updates(frame, state):
+                        yield update

--- a/custom_components/nest_protect/pynest/client.py
+++ b/custom_components/nest_protect/pynest/client.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import AsyncIterator
 from random import randint
 from types import TracebackType
 from typing import Any, cast
+from uuid import uuid4
 
+import httpx
 from aiohttp import ClientSession, ClientTimeout, ContentTypeError, FormData
 
 from .const import (
@@ -15,6 +18,8 @@ from .const import (
     DEFAULT_NEST_ENVIRONMENT,
     NEST_AUTH_URL_JWT,
     NEST_REQUEST,
+    OBSERVE_PATH,
+    SEND_COMMAND_PATH,
     TOKEN_URL,
     USER_AGENT,
 )
@@ -35,6 +40,14 @@ from .models import (
     NestAuthResponse,
     NestEnvironment,
     NestResponse,
+)
+from .protobuf import (
+    ProtobufObserveState,
+    ProtobufObserveUpdate,
+    decode_observe_stream_frames,
+    decode_structure_updates,
+    encode_observe_request,
+    encode_structure_mode_resource_command_request,
 )
 
 _LOGGER = logging.getLogger(__package__)
@@ -409,3 +422,88 @@ class NestClient:
             # TODO type object
 
             return result
+
+    async def send_structure_mode_command(
+        self,
+        nest_access_token: str,
+        structure_resource_id: str,
+        user_id: str,
+        home: bool,
+    ) -> bytes:
+        """Send a protobuf structure Home/Away command."""
+        payload = encode_structure_mode_resource_command_request(
+            structure_resource_id=structure_resource_id,
+            user_id=user_id,
+            home=home,
+        )
+
+        timeout = httpx.Timeout(60.0, connect=30.0, write=30.0, pool=30.0)
+
+        async with httpx.AsyncClient(http2=True, timeout=timeout) as client:
+            response = await client.post(
+                self.environment.grpc_host + SEND_COMMAND_PATH,
+                content=payload,
+                headers={
+                    "Authorization": f"Basic {nest_access_token}",
+                    "Content-Type": "application/x-protobuf",
+                    "User-Agent": USER_AGENT,
+                    "X-Accept-Content-Transfer-Encoding": "binary",
+                    "X-Accept-Response-Streaming": "true",
+                },
+            )
+
+            if response.status_code == 401:
+                raise NotAuthenticatedException(await response.aread())
+
+            if response.status_code >= 400:
+                raise PynestException(
+                    f"{response.status_code} error while sending structure mode command - {await response.aread()}"
+                )
+
+            return await response.aread()
+
+    async def observe_for_structure_updates(
+        self,
+        nest_access_token: str,
+    ) -> AsyncIterator[ProtobufObserveUpdate]:
+        """Observe protobuf structure and temperature sensor updates."""
+        pending = b""
+        state = ProtobufObserveState()
+        headers = {
+            "Authorization": f"Basic {nest_access_token}",
+            "Content-Type": "application/x-protobuf",
+            "User-Agent": USER_AGENT,
+            "X-Accept-Content-Transfer-Encoding": "binary",
+            "X-Accept-Response-Streaming": "true",
+            "request-id": str(uuid4()),
+            "referer": self.environment.host + "/",
+            "origin": self.environment.host,
+            "x-nl-webapp-version": "NlAppSDKVersion/8.15.0 NlSchemaVersion/2.1.20-87-gce5742894",
+        }
+
+        timeout = httpx.Timeout(600.0, connect=30.0, write=30.0, pool=30.0)
+
+        async with (
+            httpx.AsyncClient(http2=True, timeout=timeout) as client,
+            client.stream(
+                "POST",
+                self.environment.grpc_host + OBSERVE_PATH,
+                headers=headers,
+                content=encode_observe_request(),
+            ) as response,
+        ):
+            if response.status_code == 401:
+                raise NotAuthenticatedException(await response.aread())
+
+            if response.status_code >= 400:
+                raise PynestException(
+                    f"{response.status_code} error while observing protobuf structure updates - {await response.aread()}"
+                )
+
+            async for chunk in response.aiter_bytes():
+                pending += chunk
+                frames, pending = decode_observe_stream_frames(pending)
+
+                for frame in frames:
+                    for update in decode_structure_updates(frame, state):
+                        yield update

--- a/custom_components/nest_protect/pynest/client.py
+++ b/custom_components/nest_protect/pynest/client.py
@@ -109,6 +109,10 @@ class NestClient:
         # self.issue_token = issue_token
         # self.cookies = cookies
         self.environment = environment
+        # Survives observe reconnects on purpose: the gateway re-enumerates
+        # every resource on a new stream, and the device map has to be carried
+        # over or every reconnect re-runs the trait ordering race from scratch.
+        self.protobuf_observe_state = ProtobufObserveState()
 
     async def __aenter__(self) -> NestClient:
         """__aenter__."""
@@ -468,7 +472,7 @@ class NestClient:
     ) -> AsyncIterator[ProtobufObserveUpdate]:
         """Observe protobuf structure and temperature sensor updates."""
         pending = b""
-        state = ProtobufObserveState()
+        state = self.protobuf_observe_state
         headers = {
             "Authorization": f"Basic {nest_access_token}",
             "Content-Type": "application/x-protobuf",

--- a/custom_components/nest_protect/pynest/const.py
+++ b/custom_components/nest_protect/pynest/const.py
@@ -10,11 +10,13 @@ NEST_ENVIRONMENTS: dict[str, NestEnvironment] = {
         name="Google Account",
         client_id="733249279899-1gpkq9duqmdp55a7e5lft1pr2smumdla.apps.googleusercontent.com",  # Nest iOS application
         host="https://home.nest.com",
+        grpc_host="https://grpc-web.production.nest.com",
     ),
     Environment.FIELDTEST: NestEnvironment(
         name="Google Account (Field Test)",
         client_id="384529615266-57v6vaptkmhm64n9hn5dcmkr4at14p8j.apps.googleusercontent.com",  # Test Flight Beta Nest iOS application
         host="https://home.ft.nest.com",
+        grpc_host="https://grpc-web.ft.nest.com",
     ),
 }
 
@@ -26,6 +28,8 @@ TOKEN_URL = "https://oauth2.googleapis.com/token"
 # App launch API endpoint
 APP_LAUNCH_URL_FORMAT = "{host}/api/0.1/user/{user_id}/app_launch"
 NEST_AUTH_URL_JWT = "https://nestauthproxyservice-pa.googleapis.com/v1/issue_jwt"
+SEND_COMMAND_PATH = "/nestlabs.gateway.v1.ResourceApi/SendCommand"
+OBSERVE_PATH = "/nestlabs.gateway.v2.GatewayService/Observe"
 
 NEST_REQUEST = {
     "known_bucket_types": [

--- a/custom_components/nest_protect/pynest/const.py
+++ b/custom_components/nest_protect/pynest/const.py
@@ -17,11 +17,13 @@ NEST_ENVIRONMENTS: dict[str, NestEnvironment] = {
         name="Google Account",
         client_id="733249279899-1gpkq9duqmdp55a7e5lft1pr2smumdla.apps.googleusercontent.com",  # Nest iOS application
         host="https://home.nest.com",
+        grpc_host="https://grpc-web.production.nest.com",
     ),
     Environment.FIELDTEST: NestEnvironment(
         name="Google Account (Field Test)",
         client_id="384529615266-57v6vaptkmhm64n9hn5dcmkr4at14p8j.apps.googleusercontent.com",  # Test Flight Beta Nest iOS application
         host="https://home.ft.nest.com",
+        grpc_host="https://grpc-web.ft.nest.com",
     ),
 }
 
@@ -33,6 +35,8 @@ TOKEN_URL = "https://oauth2.googleapis.com/token"
 # App launch API endpoint
 APP_LAUNCH_URL_FORMAT = "{host}/api/0.1/user/{user_id}/app_launch"
 NEST_AUTH_URL_JWT = "https://nestauthproxyservice-pa.googleapis.com/v1/issue_jwt"
+SEND_COMMAND_PATH = "/nestlabs.gateway.v1.ResourceApi/SendCommand"
+OBSERVE_PATH = "/nestlabs.gateway.v2.GatewayService/Observe"
 
 NEST_REQUEST = {
     "known_bucket_types": [

--- a/custom_components/nest_protect/pynest/models.py
+++ b/custom_components/nest_protect/pynest/models.py
@@ -314,6 +314,7 @@ class NestEnvironment:
     name: str
     client_id: str
     host: str
+    grpc_host: str
 
 
 @dataclass

--- a/custom_components/nest_protect/pynest/protobuf.py
+++ b/custom_components/nest_protect/pynest/protobuf.py
@@ -1,0 +1,503 @@
+"""Small protobuf helpers for Nest gateway commands and observe messages."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from struct import unpack
+from uuid import uuid4
+
+NEST_KRYPTONITE_RESOURCE = "nest.resource.NestKryptoniteResource"
+
+STRUCTURE_MODE_HOME = 1
+STRUCTURE_MODE_AWAY = 2
+STRUCTURE_MODE_SLEEP = 3
+STRUCTURE_MODE_VACATION = 4
+STRUCTURE_MODE_REASON_EXPLICIT_INTENT = 1
+
+USER_INFO_TYPE_URL = "type.nestlabs.com/nest.trait.user.UserInfoTrait"
+STRUCTURE_INFO_TYPE_URL = "type.nestlabs.com/nest.trait.structure.StructureInfoTrait"
+STRUCTURE_MODE_TYPE_URL = (
+    "type.nestlabs.com/nest.trait.occupancy.StructureModeTrait"
+)
+PEER_DEVICES_TYPE_URL = "type.nestlabs.com/weave.trait.peerdevices.PeerDevicesTrait"
+LIVENESS_TYPE_URL = "type.nestlabs.com/weave.trait.heartbeat.LivenessTrait"
+DEVICE_IDENTITY_TYPE_URL = (
+    "type.nestlabs.com/weave.trait.description.DeviceIdentityTrait"
+)
+DEVICE_LOCATED_SETTINGS_TYPE_URL = (
+    "type.nestlabs.com/nest.trait.located.DeviceLocatedSettingsTrait"
+)
+TEMPERATURE_TYPE_URL = "type.nestlabs.com/nest.trait.sensor.TemperatureTrait"
+BATTERY_TYPE_URL = "type.nestlabs.com/weave.trait.power.BatteryPowerSourceTrait"
+STRUCTURE_MODE_CHANGE_TYPE_URL = (
+    "type.nestlabs.com/"
+    "nest.trait.occupancy.StructureModeTrait.StructureModeChangeRequest"
+)
+LIVENESS_DEVICE_STATUS_ONLINE = 1
+VARINT_CONTINUATION_LIMIT = 0x7F
+VARINT_CONTINUATION_BIT = 0x80
+FIXED32_LENGTH = 4
+FIXED64_LENGTH = 8
+WIRE_TYPE_VARINT = 0
+WIRE_TYPE_FIXED64 = 1
+WIRE_TYPE_LENGTH_DELIMITED = 2
+WIRE_TYPE_FIXED32 = 5
+OBJECT_FIELD = 1
+DYNAMIC_PROPERTY_FIELD = 3
+
+OBSERVE_TRAITS = (
+    "nest.trait.user.UserInfoTrait",
+    "nest.trait.structure.StructureInfoTrait",
+    "nest.trait.occupancy.StructureModeTrait",
+    "weave.trait.peerdevices.PeerDevicesTrait",
+    "weave.trait.heartbeat.LivenessTrait",
+    "weave.trait.description.DeviceIdentityTrait",
+    "nest.trait.located.DeviceLocatedSettingsTrait",
+    "nest.trait.sensor.TemperatureTrait",
+    "weave.trait.power.BatteryPowerSourceTrait",
+)
+
+
+@dataclass(frozen=True)
+class ProtobufStructureUpdate:
+    """Structure metadata or mode update decoded from the observe stream."""
+
+    resource_id: str
+    legacy_structure_id: str | None = None
+    user_id: str | None = None
+    away: bool | None = None
+
+
+@dataclass(frozen=True)
+class ProtobufDeviceUpdate:
+    """Device update decoded from the observe stream."""
+
+    object_key: str
+    value: dict
+
+
+ProtobufObserveUpdate = ProtobufStructureUpdate | ProtobufDeviceUpdate
+
+
+@dataclass
+class ProtobufObserveState:
+    """Mutable mapping state needed while decoding protobuf observe messages."""
+
+    user_id: str | None = None
+    legacy_structure_ids: dict[str, str] = field(default_factory=dict)
+    device_types: dict[str, str] = field(default_factory=dict)
+
+
+def _varint(value: int) -> bytes:
+    """Encode an integer as a protobuf varint."""
+    encoded = bytearray()
+    while value > VARINT_CONTINUATION_LIMIT:
+        encoded.append((value & VARINT_CONTINUATION_LIMIT) | VARINT_CONTINUATION_BIT)
+        value >>= 7
+    encoded.append(value)
+    return bytes(encoded)
+
+
+def _read_varint(buffer: bytes, offset: int = 0) -> tuple[int, int]:
+    value = 0
+    shift = 0
+    index = offset
+    while index < len(buffer):
+        byte = buffer[index]
+        index += 1
+        value |= (byte & VARINT_CONTINUATION_LIMIT) << shift
+        if not byte & VARINT_CONTINUATION_BIT:
+            return value, index
+        shift += 7
+    raise ValueError("Incomplete protobuf varint")
+
+
+def _key(field_number: int, wire_type: int) -> bytes:
+    return _varint((field_number << 3) | wire_type)
+
+
+def _field_varint(field_number: int, value: int) -> bytes:
+    return _key(field_number, 0) + _varint(value)
+
+
+def _field_bytes(field_number: int, value: bytes) -> bytes:
+    return _key(field_number, 2) + _varint(len(value)) + value
+
+
+def _field_string(field_number: int, value: str) -> bytes:
+    return _field_bytes(field_number, value.encode())
+
+
+def _resource_id(resource_id: str) -> bytes:
+    return _field_string(1, resource_id)
+
+
+def encode_structure_mode_change_request(*, home: bool, user_id: str) -> bytes:
+    """Encode StructureModeTrait.StructureModeChangeRequest."""
+    return b"".join(
+        (
+            _field_varint(
+                1,
+                STRUCTURE_MODE_HOME if home else STRUCTURE_MODE_AWAY,
+            ),
+            _field_varint(2, STRUCTURE_MODE_REASON_EXPLICIT_INTENT),
+            _field_bytes(3, _resource_id(user_id)),
+        )
+    )
+
+
+def _any(type_url: str, value: bytes) -> bytes:
+    return _field_string(1, type_url) + _field_bytes(2, value)
+
+
+def _resource_request(resource_id: str) -> bytes:
+    return _field_string(1, resource_id) + _field_string(2, str(uuid4()))
+
+
+def _resource_command(*, home: bool, user_id: str) -> bytes:
+    command = encode_structure_mode_change_request(home=home, user_id=user_id)
+    return _field_string(1, "structure_mode") + _field_bytes(
+        2, _any(STRUCTURE_MODE_CHANGE_TYPE_URL, command)
+    )
+
+
+def encode_structure_mode_resource_command_request(
+    *,
+    structure_resource_id: str,
+    home: bool,
+    user_id: str,
+) -> bytes:
+    """Encode nestlabs.gateway.v1.ResourceCommandRequest."""
+    return b"".join(
+        (
+            _field_bytes(1, _resource_request(structure_resource_id)),
+            _field_bytes(2, _resource_command(home=home, user_id=user_id)),
+        )
+    )
+
+
+def encode_observe_request(traits: Iterable[str] = OBSERVE_TRAITS) -> bytes:
+    """Encode the Nest GatewayService/Observe request trait list.
+
+    Homebridge sends a much larger trait catalog; Home/Away only needs these
+    structure/user traits.
+    """
+    return b"".join(
+        (
+            _field_bytes(1, b"\x02\x01"),
+            *(_field_bytes(3, _field_string(1, trait)) for trait in traits),
+        )
+    )
+
+
+def decode_observe_stream_frames(
+    buffer: bytes,
+) -> tuple[list[bytes], bytes]:
+    """Decode complete StreamBody messages from the observe byte stream."""
+    frames: list[bytes] = []
+    offset = 0
+
+    while offset < len(buffer):
+        try:
+            key, length_offset = _read_varint(buffer, offset)
+            if key & 0x07 != WIRE_TYPE_LENGTH_DELIMITED:
+                break
+            frame_length, body_offset = _read_varint(buffer, length_offset)
+        except ValueError:
+            break
+
+        frame_end = body_offset + frame_length
+        if len(buffer) < frame_end:
+            break
+
+        frames.append(buffer[offset:frame_end])
+        offset = frame_end
+
+    return frames, buffer[offset:]
+
+
+def decode_structure_updates(
+    payload: bytes,
+    state: ProtobufObserveState | None = None,
+) -> list[ProtobufObserveUpdate]:
+    """Decode structure and temperature sensor updates from a StreamBody."""
+    state = state or ProtobufObserveState()
+    updates: list[ProtobufObserveUpdate] = []
+
+    for _, message in _bytes_fields(payload, 1):
+        for _, get_property in _bytes_fields(message, 3):
+            update = _decode_get_property(get_property, state)
+            if isinstance(update, list):
+                updates.extend(update)
+            elif update:
+                updates.append(update)
+
+    return updates
+
+
+def _decode_get_property(
+    payload: bytes,
+    state: ProtobufObserveState,
+) -> ProtobufObserveUpdate | list[ProtobufObserveUpdate] | None:
+    object_id = None
+    type_url = None
+    value = None
+
+    for field_number, _, field_value in _decode_fields(payload):
+        if field_number == OBJECT_FIELD and isinstance(field_value, bytes):
+            object_id = _first_string_field(field_value, 1)
+        elif field_number == DYNAMIC_PROPERTY_FIELD and isinstance(field_value, bytes):
+            any_payload = _first_bytes_field(field_value, 1)
+            if any_payload:
+                type_url = _first_string_field(any_payload, 1)
+                value = _first_bytes_field(any_payload, 2)
+
+    if not object_id or not type_url or value is None:
+        return None
+
+    if type_url == USER_INFO_TYPE_URL:
+        state.user_id = object_id
+        return None
+
+    if type_url == STRUCTURE_INFO_TYPE_URL:
+        legacy_id = _first_string_field(value, 1)
+        legacy_structure_id = legacy_id.split(".", 1)[1] if legacy_id else None
+        if legacy_structure_id:
+            state.legacy_structure_ids[object_id] = legacy_structure_id
+        return ProtobufStructureUpdate(
+            resource_id=object_id,
+            legacy_structure_id=legacy_structure_id,
+            user_id=state.user_id,
+        )
+
+    if type_url == STRUCTURE_MODE_TYPE_URL:
+        structure_mode = _first_varint_field(value, 1)
+        if structure_mode is None:
+            return None
+
+        return ProtobufStructureUpdate(
+            resource_id=object_id,
+            legacy_structure_id=state.legacy_structure_ids.get(object_id),
+            user_id=state.user_id,
+            away=structure_mode
+            in {STRUCTURE_MODE_AWAY, STRUCTURE_MODE_SLEEP, STRUCTURE_MODE_VACATION},
+        )
+
+    if type_url == PEER_DEVICES_TYPE_URL:
+        return _decode_peer_devices(object_id, value, state)
+
+    return _decode_device_property(object_id, type_url, value, state)
+
+
+def _decode_peer_devices(
+    structure_resource_id: str,
+    payload: bytes,
+    state: ProtobufObserveState,
+) -> list[ProtobufDeviceUpdate]:
+    legacy_structure_id = state.legacy_structure_ids.get(structure_resource_id)
+    if not legacy_structure_id:
+        return []
+
+    updates: list[ProtobufDeviceUpdate] = []
+    for _, peer_device in _bytes_fields(payload, 1):
+        data = _first_bytes_field(peer_device, 2)
+        if not data:
+            continue
+
+        resource_id = _indirect_string(data, 1)
+        device_type = _indirect_string(data, 2)
+        if not resource_id or device_type != NEST_KRYPTONITE_RESOURCE:
+            continue
+
+        device_id = _legacy_device_id(resource_id)
+        state.device_types[device_id] = device_type
+        updates.append(
+            ProtobufDeviceUpdate(
+                object_key=f"kryptonite.{device_id}",
+                value={
+                    "using_protobuf": True,
+                    "device_id": device_id,
+                    "structure_id": legacy_structure_id,
+                    "current_version": _first_string_field(data, 5),
+                    "user_id": state.user_id,
+                    "protobuf_device_type": device_type,
+                },
+            )
+        )
+
+    return updates
+
+
+def _decode_device_property(
+    resource_id: str,
+    type_url: str,
+    payload: bytes,
+    state: ProtobufObserveState,
+) -> ProtobufDeviceUpdate | None:
+    device_id = _legacy_device_id(resource_id)
+    if state.device_types.get(device_id) != NEST_KRYPTONITE_RESOURCE:
+        return None
+
+    if type_url == LIVENESS_TYPE_URL:
+        return _decode_liveness(device_id, payload)
+
+    if type_url == DEVICE_IDENTITY_TYPE_URL:
+        return _device_update(
+            device_id,
+            {
+                "model": _indirect_string(payload, 4),
+                "serial_number": _first_string_field(payload, 6),
+                "current_version": _first_string_field(payload, 7),
+            },
+        )
+
+    if type_url == DEVICE_LOCATED_SETTINGS_TYPE_URL:
+        update = {"where_id": _indirect_string(payload, 2)}
+        fixture_type = _first_bytes_field(payload, 4)
+        if fixture_type:
+            update["fixture_type"] = _first_varint_field(fixture_type, 1)
+        return _device_update(device_id, update)
+
+    if type_url == TEMPERATURE_TYPE_URL:
+        temperature = _nested_float(payload, 1, 1, 1)
+        if temperature is None:
+            return None
+        return ProtobufDeviceUpdate(
+            object_key=f"kryptonite.{device_id}",
+            value={"current_temperature": temperature},
+        )
+
+    if type_url == BATTERY_TYPE_URL:
+        return _device_update(
+            device_id,
+            {
+                "battery_status": _first_varint_field(payload, 32),
+                "battery_level": _nested_float(payload, 33, 1, 1),
+            },
+        )
+
+    return None
+
+
+def _decode_liveness(device_id: str, payload: bytes) -> ProtobufDeviceUpdate | None:
+    status = _first_varint_field(payload, 1)
+    if status is None:
+        return None
+    return ProtobufDeviceUpdate(
+        object_key=f"kryptonite.{device_id}",
+        value={"is_online": status == LIVENESS_DEVICE_STATUS_ONLINE},
+    )
+
+
+def _device_update(device_id: str, values: dict) -> ProtobufDeviceUpdate | None:
+    value = {key: val for key, val in values.items() if val is not None}
+    if not value:
+        return None
+    return ProtobufDeviceUpdate(object_key=f"kryptonite.{device_id}", value=value)
+
+
+def _decode_fields(payload: bytes) -> list[tuple[int, int, int | bytes]]:
+    fields: list[tuple[int, int, int | bytes]] = []
+    offset = 0
+
+    while offset < len(payload):
+        key, offset = _read_varint(payload, offset)
+        field_number = key >> 3
+        wire_type = key & 0x07
+
+        if wire_type == WIRE_TYPE_VARINT:
+            value, offset = _read_varint(payload, offset)
+        elif wire_type == WIRE_TYPE_LENGTH_DELIMITED:
+            length, offset = _read_varint(payload, offset)
+            value = payload[offset : offset + length]
+            offset += length
+        elif wire_type == WIRE_TYPE_FIXED32:
+            value = payload[offset : offset + FIXED32_LENGTH]
+            offset += FIXED32_LENGTH
+        elif wire_type == WIRE_TYPE_FIXED64:
+            value = payload[offset : offset + FIXED64_LENGTH]
+            offset += FIXED64_LENGTH
+        else:
+            break
+
+        fields.append((field_number, wire_type, value))
+
+    return fields
+
+
+def _bytes_fields(payload: bytes, field_number: int) -> list[tuple[int, bytes]]:
+    return [
+        (decoded_field, value)
+        for decoded_field, wire_type, value in _decode_fields(payload)
+        if decoded_field == field_number
+        and wire_type == WIRE_TYPE_LENGTH_DELIMITED
+        and isinstance(value, bytes)
+    ]
+
+
+def _first_bytes_field(payload: bytes, field_number: int) -> bytes | None:
+    for decoded_field, wire_type, value in _decode_fields(payload):
+        if (
+            decoded_field == field_number
+            and wire_type == WIRE_TYPE_LENGTH_DELIMITED
+            and isinstance(value, bytes)
+        ):
+            return value
+    return None
+
+
+def _first_string_field(payload: bytes, field_number: int) -> str | None:
+    value = _first_bytes_field(payload, field_number)
+    if value is None:
+        return None
+    return value.decode()
+
+
+def _first_varint_field(payload: bytes, field_number: int) -> int | None:
+    for decoded_field, wire_type, value in _decode_fields(payload):
+        if (
+            decoded_field == field_number
+            and wire_type == WIRE_TYPE_VARINT
+            and isinstance(value, int)
+        ):
+            return value
+    return None
+
+
+def _first_fixed32_field(payload: bytes, field_number: int) -> bytes | None:
+    for decoded_field, wire_type, value in _decode_fields(payload):
+        if (
+            decoded_field == field_number
+            and wire_type == WIRE_TYPE_FIXED32
+            and isinstance(value, bytes)
+        ):
+            return value
+    return None
+
+
+def _first_float_field(payload: bytes, field_number: int) -> float | None:
+    value = _first_fixed32_field(payload, field_number)
+    if value is None:
+        return None
+    return unpack("<f", value)[0]
+
+
+def _nested_float(payload: bytes, *field_numbers: int) -> float | None:
+    current = payload
+    for field_number in field_numbers[:-1]:
+        current = _first_bytes_field(current, field_number)
+        if current is None:
+            return None
+    return _first_float_field(current, field_numbers[-1])
+
+
+def _indirect_string(payload: bytes, field_number: int) -> str | None:
+    indirect = _first_bytes_field(payload, field_number)
+    if not indirect:
+        return None
+    return _first_string_field(indirect, 1)
+
+
+def _legacy_device_id(resource_id: str) -> str:
+    return resource_id.removeprefix("DEVICE_")

--- a/custom_components/nest_protect/pynest/protobuf.py
+++ b/custom_components/nest_protect/pynest/protobuf.py
@@ -17,9 +17,7 @@ STRUCTURE_MODE_REASON_EXPLICIT_INTENT = 1
 
 USER_INFO_TYPE_URL = "type.nestlabs.com/nest.trait.user.UserInfoTrait"
 STRUCTURE_INFO_TYPE_URL = "type.nestlabs.com/nest.trait.structure.StructureInfoTrait"
-STRUCTURE_MODE_TYPE_URL = (
-    "type.nestlabs.com/nest.trait.occupancy.StructureModeTrait"
-)
+STRUCTURE_MODE_TYPE_URL = "type.nestlabs.com/nest.trait.occupancy.StructureModeTrait"
 PEER_DEVICES_TYPE_URL = "type.nestlabs.com/weave.trait.peerdevices.PeerDevicesTrait"
 LIVENESS_TYPE_URL = "type.nestlabs.com/weave.trait.heartbeat.LivenessTrait"
 DEVICE_IDENTITY_TYPE_URL = (

--- a/custom_components/nest_protect/pynest/protobuf.py
+++ b/custom_components/nest_protect/pynest/protobuf.py
@@ -9,6 +9,31 @@ from uuid import uuid4
 
 NEST_KRYPTONITE_RESOURCE = "nest.resource.NestKryptoniteResource"
 
+# Thermostat resource types, mirroring homebridge-nest's `peer_devices` handling
+# and tronikos/nest_legacy's model table. Google-branded resources are the newer
+# hardware (Thermostat 2020, Learning Thermostat 4th gen).
+NEST_THERMOSTAT_RESOURCES = frozenset(
+    {
+        "nest.resource.NestLearningThermostat1Resource",
+        "nest.resource.NestLearningThermostat2Resource",
+        "nest.resource.NestLearningThermostat3Resource",
+        "nest.resource.NestLearningThermostat3v2Resource",
+        "nest.resource.NestThermostat3Resource",
+        "nest.resource.NestAmber1DisplayResource",
+        "nest.resource.NestAmber2DisplayResource",
+        "nest.resource.NestAgateDisplayResource",  # Thermostat E
+        "nest.resource.NestOnyxResource",  # Thermostat E (US, 1st gen)
+        "google.resource.GoogleZirconium1Resource",  # Thermostat (2020)
+        "google.resource.GoogleBismuth1Resource",  # Learning Thermostat (4th gen)
+    }
+)
+
+# Protobuf resource type -> legacy bucket prefix. Thermostats use the same
+# `device.` prefix the legacy REST API gives them.
+BUCKET_PREFIXES = {NEST_KRYPTONITE_RESOURCE: "kryptonite"} | dict.fromkeys(
+    NEST_THERMOSTAT_RESOURCES, "device"
+)
+
 STRUCTURE_MODE_HOME = 1
 STRUCTURE_MODE_AWAY = 2
 STRUCTURE_MODE_SLEEP = 3
@@ -28,11 +53,21 @@ DEVICE_LOCATED_SETTINGS_TYPE_URL = (
 )
 TEMPERATURE_TYPE_URL = "type.nestlabs.com/nest.trait.sensor.TemperatureTrait"
 BATTERY_TYPE_URL = "type.nestlabs.com/weave.trait.power.BatteryPowerSourceTrait"
+RCS_SETTINGS_TYPE_URL = (
+    "type.nestlabs.com/nest.trait.hvac.RemoteComfortSensingSettingsTrait"
+)
 STRUCTURE_MODE_CHANGE_TYPE_URL = (
     "type.nestlabs.com/"
     "nest.trait.occupancy.StructureModeTrait.StructureModeChangeRequest"
 )
 LIVENESS_DEVICE_STATUS_ONLINE = 1
+
+# RemoteComfortSensingSettingsTrait.RcsSourceType — which temperature source the
+# thermostat is currently controlling on.
+RCS_SOURCE_TYPE_BACKPLATE = 1
+RCS_SOURCE_TYPE_SINGLE_SENSOR = 2
+RCS_SOURCE_TYPE_MULTI_SENSOR = 3
+
 VARINT_CONTINUATION_LIMIT = 0x7F
 VARINT_CONTINUATION_BIT = 0x80
 FIXED32_LENGTH = 4
@@ -43,6 +78,14 @@ WIRE_TYPE_LENGTH_DELIMITED = 2
 WIRE_TYPE_FIXED32 = 5
 OBJECT_FIELD = 1
 DYNAMIC_PROPERTY_FIELD = 3
+# ObjectIdPair is {id = 1, key = 2}, where `key` is the trait label. Thermostats
+# publish TemperatureTrait twice and only the label tells the two apart.
+OBJECT_ID_FIELD = 1
+TRAIT_LABEL_FIELD = 2
+TRAIT_LABEL_BACKPLATE_TEMPERATURE = "backplate_temperature"
+TRAIT_LABEL_CURRENT_TEMPERATURE = "current_temperature"
+# Bucketized labels carry temperature history series, not the current reading.
+BUCKETIZED_LABEL_SUFFIX = "_bucketized"
 
 OBSERVE_TRAITS = (
     "nest.trait.user.UserInfoTrait",
@@ -54,6 +97,7 @@ OBSERVE_TRAITS = (
     "nest.trait.located.DeviceLocatedSettingsTrait",
     "nest.trait.sensor.TemperatureTrait",
     "weave.trait.power.BatteryPowerSourceTrait",
+    "nest.trait.hvac.RemoteComfortSensingSettingsTrait",
 )
 
 
@@ -239,12 +283,14 @@ def _decode_get_property(
     state: ProtobufObserveState,
 ) -> ProtobufObserveUpdate | list[ProtobufObserveUpdate] | None:
     object_id = None
+    trait_label = None
     type_url = None
     value = None
 
     for field_number, _, field_value in _decode_fields(payload):
         if field_number == OBJECT_FIELD and isinstance(field_value, bytes):
-            object_id = _first_string_field(field_value, 1)
+            object_id = _first_string_field(field_value, OBJECT_ID_FIELD)
+            trait_label = _first_string_field(field_value, TRAIT_LABEL_FIELD)
         elif field_number == DYNAMIC_PROPERTY_FIELD and isinstance(field_value, bytes):
             any_payload = _first_bytes_field(field_value, 1)
             if any_payload:
@@ -252,6 +298,9 @@ def _decode_get_property(
                 value = _first_bytes_field(any_payload, 2)
 
     if not object_id or not type_url or value is None:
+        return None
+
+    if trait_label and trait_label.endswith(BUCKETIZED_LABEL_SUFFIX):
         return None
 
     if type_url == USER_INFO_TYPE_URL:
@@ -285,7 +334,7 @@ def _decode_get_property(
     if type_url == PEER_DEVICES_TYPE_URL:
         return _decode_peer_devices(object_id, value, state)
 
-    return _decode_device_property(object_id, type_url, value, state)
+    return _decode_device_property(object_id, type_url, value, state, trait_label)
 
 
 def _decode_peer_devices(
@@ -305,14 +354,18 @@ def _decode_peer_devices(
 
         resource_id = _indirect_string(data, 1)
         device_type = _indirect_string(data, 2)
-        if not resource_id or device_type != NEST_KRYPTONITE_RESOURCE:
+        if not resource_id or not device_type:
+            continue
+
+        prefix = BUCKET_PREFIXES.get(device_type)
+        if not prefix:
             continue
 
         device_id = _legacy_device_id(resource_id)
         state.device_types[device_id] = device_type
         updates.append(
             ProtobufDeviceUpdate(
-                object_key=f"kryptonite.{device_id}",
+                object_key=f"{prefix}.{device_id}",
                 value={
                     "using_protobuf": True,
                     "device_id": device_id,
@@ -332,17 +385,22 @@ def _decode_device_property(
     type_url: str,
     payload: bytes,
     state: ProtobufObserveState,
+    trait_label: str | None = None,
 ) -> ProtobufDeviceUpdate | None:
     device_id = _legacy_device_id(resource_id)
-    if state.device_types.get(device_id) != NEST_KRYPTONITE_RESOURCE:
+    device_type = state.device_types.get(device_id)
+    prefix = BUCKET_PREFIXES.get(device_type) if device_type else None
+    if not prefix:
         return None
 
+    object_key = f"{prefix}.{device_id}"
+
     if type_url == LIVENESS_TYPE_URL:
-        return _decode_liveness(device_id, payload)
+        return _decode_liveness(object_key, payload)
 
     if type_url == DEVICE_IDENTITY_TYPE_URL:
         return _device_update(
-            device_id,
+            object_key,
             {
                 "model": _indirect_string(payload, 4),
                 "serial_number": _first_string_field(payload, 6),
@@ -355,44 +413,105 @@ def _decode_device_property(
         fixture_type = _first_bytes_field(payload, 4)
         if fixture_type:
             update["fixture_type"] = _first_varint_field(fixture_type, 1)
-        return _device_update(device_id, update)
+        return _device_update(object_key, update)
 
     if type_url == TEMPERATURE_TYPE_URL:
         temperature = _nested_float(payload, 1, 1, 1)
         if temperature is None:
             return None
-        return ProtobufDeviceUpdate(
-            object_key=f"kryptonite.{device_id}",
-            value={"current_temperature": temperature},
+        # Thermostats publish this trait twice: `backplate_temperature` is the
+        # device's own sensor, `current_temperature` the effective reading, which
+        # follows the selected remote comfort sensor. Kryptonite sensors send a
+        # single unlabelled instance, which stays the current temperature.
+        key = (
+            TRAIT_LABEL_BACKPLATE_TEMPERATURE
+            if trait_label == TRAIT_LABEL_BACKPLATE_TEMPERATURE
+            else TRAIT_LABEL_CURRENT_TEMPERATURE
         )
+        return ProtobufDeviceUpdate(object_key=object_key, value={key: temperature})
 
     if type_url == BATTERY_TYPE_URL:
         return _device_update(
-            device_id,
+            object_key,
             {
                 "battery_status": _first_varint_field(payload, 32),
                 "battery_level": _nested_float(payload, 33, 1, 1),
             },
         )
 
+    if type_url == RCS_SETTINGS_TYPE_URL:
+        # Not filtered through _device_update: `None` and `[]` have to survive so
+        # that reverting to the thermostat's own sensor clears the old selection.
+        return ProtobufDeviceUpdate(
+            object_key=object_key, value=_decode_rcs_settings(payload)
+        )
+
     return None
 
 
-def _decode_liveness(device_id: str, payload: bytes) -> ProtobufDeviceUpdate | None:
+def _decode_rcs_settings(payload: bytes) -> dict:
+    """Decode RemoteComfortSensingSettingsTrait.
+
+    Reports which temperature source the thermostat controls on: its own
+    backplate, one associated Nest Temperature Sensor, or an average over a
+    group of them.
+    """
+    selection = _first_bytes_field(payload, 2)
+    source_type = _first_varint_field(selection, 1) if selection else None
+    single_sensor = _indirect_string(selection, 2) if selection else None
+
+    multi_settings = _first_bytes_field(payload, 5)
+    multi_group = (
+        [
+            resource_id
+            for _, group in _bytes_fields(multi_settings, 2)
+            if (resource_id := _first_string_field(group, 1))
+        ]
+        if multi_settings
+        else []
+    )
+
+    if source_type == RCS_SOURCE_TYPE_MULTI_SENSOR:
+        active = multi_group
+    elif source_type == RCS_SOURCE_TYPE_SINGLE_SENSOR and single_sensor:
+        active = [single_sensor]
+    else:
+        active = []
+
+    associated = [
+        resource_id
+        for _, sensor in _bytes_fields(payload, 4)
+        if (resource_id := _indirect_string(sensor, 1))
+    ]
+
+    return {
+        "rcs_control_mode": _first_varint_field(payload, 1),
+        "rcs_source_type": source_type,
+        "active_rcs_sensors": [_kryptonite_key(r) for r in active],
+        "associated_rcs_sensors": [_kryptonite_key(r) for r in associated],
+    }
+
+
+def _kryptonite_key(resource_id: str) -> str:
+    """Map a sensor resource id to its legacy temperature sensor bucket key."""
+    return f"kryptonite.{_legacy_device_id(resource_id)}"
+
+
+def _decode_liveness(object_key: str, payload: bytes) -> ProtobufDeviceUpdate | None:
     status = _first_varint_field(payload, 1)
     if status is None:
         return None
     return ProtobufDeviceUpdate(
-        object_key=f"kryptonite.{device_id}",
+        object_key=object_key,
         value={"is_online": status == LIVENESS_DEVICE_STATUS_ONLINE},
     )
 
 
-def _device_update(device_id: str, values: dict) -> ProtobufDeviceUpdate | None:
+def _device_update(object_key: str, values: dict) -> ProtobufDeviceUpdate | None:
     value = {key: val for key, val in values.items() if val is not None}
     if not value:
         return None
-    return ProtobufDeviceUpdate(object_key=f"kryptonite.{device_id}", value=value)
+    return ProtobufDeviceUpdate(object_key=object_key, value=value)
 
 
 def _decode_fields(payload: bytes) -> list[tuple[int, int, int | bytes]]:

--- a/custom_components/nest_protect/pynest/protobuf.py
+++ b/custom_components/nest_protect/pynest/protobuf.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from struct import unpack
 from uuid import uuid4
+
+_LOGGER = logging.getLogger(__package__)
 
 NEST_KRYPTONITE_RESOURCE = "nest.resource.NestKryptoniteResource"
 
@@ -63,6 +66,15 @@ STRUCTURE_MODE_CHANGE_TYPE_URL = (
 )
 LIVENESS_DEVICE_STATUS_ONLINE = 1
 
+# DeviceLocatedSettingsTrait fields, per protobuf_gen/nest/trait/located_pb2.
+# `whereAnnotationRid` is a protobuf annotation resource id and is *not*
+# interchangeable with the legacy where uuid the `where.` REST buckets are keyed
+# by — that one lives in `whereLegacyUuid`.
+WHERE_ANNOTATION_RID_FIELD = 2
+FIXTURE_TYPE_FIELD = 4
+WHERE_LABEL_FIELD = 5
+WHERE_LEGACY_UUID_FIELD = 11
+
 # RemoteComfortSensingSettingsTrait.RcsSourceType — which temperature source the
 # thermostat is currently controlling on.
 RCS_SOURCE_TYPE_BACKPLATE = 1
@@ -79,12 +91,32 @@ WIRE_TYPE_LENGTH_DELIMITED = 2
 WIRE_TYPE_FIXED32 = 5
 OBJECT_FIELD = 1
 DYNAMIC_PROPERTY_FIELD = 3
-# ObjectIdPair is {id = 1, key = 2}, where `key` is the trait label. Thermostats
-# publish TemperatureTrait twice and only the label tells the two apart.
+# ObjectIdPair is {id = 1, key = 2}, where `key` is the trait label.
 OBJECT_ID_FIELD = 1
 TRAIT_LABEL_FIELD = 2
+# TraitState.stateTypes — whether a patch carries the confirmed (device-reported)
+# or accepted (server-side) copy of the trait. Decoded for logging only: the
+# observe request asks for both, so telling them apart matters when diagnosing
+# updates that appear to stall.
+STATE_TYPES_FIELD = 2
+STATE_TYPE_NAMES = {1: "confirmed", 2: "accepted"}
+
 TRAIT_LABEL_BACKPLATE_TEMPERATURE = "backplate_temperature"
 TRAIT_LABEL_CURRENT_TEMPERATURE = "current_temperature"
+TRAIT_LABEL_BACKPLATE_HUMIDITY = "backplate_humidity"
+TRAIT_LABEL_CURRENT_HUMIDITY = "current_humidity"
+
+# Thermostats publish TemperatureTrait and HumidityTrait twice, and only the
+# trait label tells the two instances apart: `backplate_*` is the device's own
+# sensor, `current_*` the effective reading, which follows the selected remote
+# comfort sensor. The label doubles as the bucket key. Kryptonite sensors send a
+# single unlabelled instance, which stays the current reading.
+TEMPERATURE_TRAIT_LABELS = frozenset(
+    {TRAIT_LABEL_BACKPLATE_TEMPERATURE, TRAIT_LABEL_CURRENT_TEMPERATURE}
+)
+HUMIDITY_TRAIT_LABELS = frozenset(
+    {TRAIT_LABEL_BACKPLATE_HUMIDITY, TRAIT_LABEL_CURRENT_HUMIDITY}
+)
 # Bucketized labels carry temperature history series, not the current reading.
 BUCKETIZED_LABEL_SUFFIX = "_bucketized"
 
@@ -122,6 +154,17 @@ class ProtobufDeviceUpdate:
 
 
 ProtobufObserveUpdate = ProtobufStructureUpdate | ProtobufDeviceUpdate
+
+
+@dataclass
+class _TraitState:
+    """One decoded `nestlabs.gateway.v2.TraitState` off the observe stream."""
+
+    object_id: str | None = None
+    trait_label: str | None = None
+    type_url: str | None = None
+    value: bytes | None = None
+    state_types: list[int] = field(default_factory=list)
 
 
 @dataclass
@@ -238,15 +281,35 @@ def encode_observe_request(traits: Iterable[str] = OBSERVE_TRAITS) -> bytes:
 def decode_observe_stream_frames(
     buffer: bytes,
 ) -> tuple[list[bytes], bytes]:
-    """Decode complete StreamBody messages from the observe byte stream."""
+    """Decode complete StreamBody messages from the observe byte stream.
+
+    Returns the frames that were complete plus whatever bytes are left over,
+    which the caller prepends to the next chunk. Every StreamBody field the
+    gateway sends is length-delimited, so any other wire type means the buffer
+    has lost sync — keeping those bytes around would poison every later chunk
+    and silently wedge the stream, so they are dropped instead.
+    """
     frames: list[bytes] = []
     offset = 0
 
     while offset < len(buffer):
         try:
             key, length_offset = _read_varint(buffer, offset)
-            if key & 0x07 != WIRE_TYPE_LENGTH_DELIMITED:
-                break
+        except ValueError:
+            # Varint split across chunks; wait for more bytes.
+            break
+
+        if key & 0x07 != WIRE_TYPE_LENGTH_DELIMITED:
+            _LOGGER.warning(
+                "Observe stream out of sync at offset %d (wire type %d), "
+                "discarding %d buffered bytes",
+                offset,
+                key & 0x07,
+                len(buffer) - offset,
+            )
+            return frames, b""
+
+        try:
             frame_length, body_offset = _read_varint(buffer, length_offset)
         except ValueError:
             break
@@ -284,25 +347,15 @@ def _decode_get_property(
     payload: bytes,
     state: ProtobufObserveState,
 ) -> ProtobufObserveUpdate | list[ProtobufObserveUpdate] | None:
-    object_id = None
-    trait_label = None
-    type_url = None
-    value = None
-
-    for field_number, _, field_value in _decode_fields(payload):
-        if field_number == OBJECT_FIELD and isinstance(field_value, bytes):
-            object_id = _first_string_field(field_value, OBJECT_ID_FIELD)
-            trait_label = _first_string_field(field_value, TRAIT_LABEL_FIELD)
-        elif field_number == DYNAMIC_PROPERTY_FIELD and isinstance(field_value, bytes):
-            any_payload = _first_bytes_field(field_value, 1)
-            if any_payload:
-                type_url = _first_string_field(any_payload, 1)
-                value = _first_bytes_field(any_payload, 2)
+    trait = _scan_trait_state(payload)
+    object_id = trait.object_id
+    type_url = trait.type_url
+    value = trait.value
 
     if not object_id or not type_url or value is None:
         return None
 
-    if trait_label and trait_label.endswith(BUCKETIZED_LABEL_SUFFIX):
+    if trait.trait_label and trait.trait_label.endswith(BUCKETIZED_LABEL_SUFFIX):
         return None
 
     if type_url == USER_INFO_TYPE_URL:
@@ -336,7 +389,52 @@ def _decode_get_property(
     if type_url == PEER_DEVICES_TYPE_URL:
         return _decode_peer_devices(object_id, value, state)
 
-    return _decode_device_property(object_id, type_url, value, state, trait_label)
+    return _decode_device_property(
+        object_id,
+        type_url,
+        value,
+        state,
+        trait_label=trait.trait_label,
+        state_types=trait.state_types,
+    )
+
+
+def _scan_trait_state(payload: bytes) -> _TraitState:
+    """Pull the identity, state types and Any-wrapped value out of a TraitState."""
+    trait = _TraitState()
+
+    for field_number, wire_type, field_value in _decode_fields(payload):
+        if field_number == OBJECT_FIELD and isinstance(field_value, bytes):
+            trait.object_id = _first_string_field(field_value, OBJECT_ID_FIELD)
+            trait.trait_label = _first_string_field(field_value, TRAIT_LABEL_FIELD)
+        elif field_number == STATE_TYPES_FIELD:
+            trait.state_types.extend(_state_types(wire_type, field_value))
+        elif field_number == DYNAMIC_PROPERTY_FIELD and isinstance(field_value, bytes):
+            any_payload = _first_bytes_field(field_value, 1)
+            if any_payload:
+                trait.type_url = _first_string_field(any_payload, 1)
+                trait.value = _first_bytes_field(any_payload, 2)
+
+    return trait
+
+
+def _state_types(wire_type: int, field_value: int | bytes) -> list[int]:
+    """Decode TraitState.stateTypes, packed or repeated."""
+    if wire_type == WIRE_TYPE_VARINT and isinstance(field_value, int):
+        return [field_value]
+
+    if wire_type != WIRE_TYPE_LENGTH_DELIMITED or not isinstance(field_value, bytes):
+        return []
+
+    values: list[int] = []
+    offset = 0
+    while offset < len(field_value):
+        try:
+            value, offset = _read_varint(field_value, offset)
+        except ValueError:
+            break
+        values.append(value)
+    return values
 
 
 def _decode_peer_devices(
@@ -387,7 +485,9 @@ def _decode_device_property(
     type_url: str,
     payload: bytes,
     state: ProtobufObserveState,
+    *,
     trait_label: str | None = None,
+    state_types: list[int] | None = None,
 ) -> ProtobufDeviceUpdate | None:
     device_id = _legacy_device_id(resource_id)
     device_type = state.device_types.get(device_id)
@@ -411,34 +511,40 @@ def _decode_device_property(
         )
 
     if type_url == DEVICE_LOCATED_SETTINGS_TYPE_URL:
-        update = {"where_id": _indirect_string(payload, 2)}
-        fixture_type = _first_bytes_field(payload, 4)
+        update = {
+            # Only `whereLegacyUuid` matches the keys `where.` REST buckets use,
+            # so it is the one that may be written to `where_id`. The annotation
+            # rid is kept under its own key for diagnostics.
+            "where_id": _first_string_field(payload, WHERE_LEGACY_UUID_FIELD),
+            "where_label": _indirect_string(payload, WHERE_LABEL_FIELD),
+            "where_annotation_rid": _indirect_string(
+                payload, WHERE_ANNOTATION_RID_FIELD
+            ),
+        }
+        fixture_type = _first_bytes_field(payload, FIXTURE_TYPE_FIELD)
         if fixture_type:
             update["fixture_type"] = _first_varint_field(fixture_type, 1)
         return _device_update(object_key, update)
 
     if type_url == TEMPERATURE_TYPE_URL:
-        temperature = _nested_float(payload, 1, 1, 1)
-        if temperature is None:
-            return None
-        # Thermostats publish this trait twice: `backplate_temperature` is the
-        # device's own sensor, `current_temperature` the effective reading, which
-        # follows the selected remote comfort sensor. Kryptonite sensors send a
-        # single unlabelled instance, which stays the current temperature.
-        key = (
-            TRAIT_LABEL_BACKPLATE_TEMPERATURE
-            if trait_label == TRAIT_LABEL_BACKPLATE_TEMPERATURE
-            else TRAIT_LABEL_CURRENT_TEMPERATURE
+        return _decode_sensor_sample(
+            object_key,
+            payload,
+            trait_label=trait_label,
+            state_types=state_types,
+            known_labels=TEMPERATURE_TRAIT_LABELS,
+            unlabelled_key=TRAIT_LABEL_CURRENT_TEMPERATURE,
         )
-        return ProtobufDeviceUpdate(object_key=object_key, value={key: temperature})
 
     if type_url == HUMIDITY_TYPE_URL:
-        # HumidityTrait has the same nesting as TemperatureTrait.
-        humidity = _nested_float(payload, 1, 1, 1)
-        if humidity is None:
-            return None
-        return ProtobufDeviceUpdate(
-            object_key=object_key, value={"current_humidity": humidity}
+        # HumidityTrait has the same nesting and the same paired labels.
+        return _decode_sensor_sample(
+            object_key,
+            payload,
+            trait_label=trait_label,
+            state_types=state_types,
+            known_labels=HUMIDITY_TRAIT_LABELS,
+            unlabelled_key=TRAIT_LABEL_CURRENT_HUMIDITY,
         )
 
     if type_url == BATTERY_TYPE_URL:
@@ -457,7 +563,49 @@ def _decode_device_property(
             object_key=object_key, value=_decode_rcs_settings(payload)
         )
 
+    _LOGGER.debug("Observe: ignoring trait %s on %s", type_url, object_key)
     return None
+
+
+def _decode_sensor_sample(
+    object_key: str,
+    payload: bytes,
+    *,
+    trait_label: str | None,
+    state_types: list[int] | None,
+    known_labels: frozenset[str],
+    unlabelled_key: str,
+) -> ProtobufDeviceUpdate | None:
+    """Decode a TemperatureTrait/HumidityTrait sample into its bucket key.
+
+    An unrecognised label is dropped rather than folded into the current
+    reading: a device publishing an instance this integration does not know
+    about must not be able to overwrite the ambient value with it.
+    """
+    if trait_label and trait_label not in known_labels:
+        _LOGGER.debug(
+            "Observe: ignoring unknown sensor trait label %s on %s",
+            trait_label,
+            object_key,
+        )
+        return None
+
+    key = trait_label or unlabelled_key
+
+    sample = _nested_float(payload, 1, 1, 1)
+    if sample is None:
+        _LOGGER.debug("Observe: no sample in %s trait on %s", key, object_key)
+        return None
+
+    _LOGGER.debug(
+        "Observe: %s %s=%s (%s)",
+        object_key,
+        key,
+        sample,
+        ", ".join(STATE_TYPE_NAMES.get(s, str(s)) for s in state_types or [])
+        or "no state types",
+    )
+    return ProtobufDeviceUpdate(object_key=object_key, value={key: sample})
 
 
 def _decode_rcs_settings(payload: bytes) -> dict:

--- a/custom_components/nest_protect/pynest/protobuf.py
+++ b/custom_components/nest_protect/pynest/protobuf.py
@@ -120,6 +120,15 @@ HUMIDITY_TRAIT_LABELS = frozenset(
 # Bucketized labels carry temperature history series, not the current reading.
 BUCKETIZED_LABEL_SUFFIX = "_bucketized"
 
+# Caps on the parked-trait buffers. The observe stream is meant to run for
+# weeks, so anything keyed by a resource id the gateway never goes on to
+# explain has to be forgettable. Within one device the parked set is keyed by
+# trait, so a device republishing its temperature every minute replaces its own
+# entry instead of adding another; these caps bound the number of *resources*
+# that can be waiting at once. Oldest-first eviction.
+MAX_PENDING_DEVICES = 64
+MAX_PENDING_STRUCTURES = 8
+
 OBSERVE_TRAITS = (
     "nest.trait.user.UserInfoTrait",
     "nest.trait.structure.StructureInfoTrait",
@@ -167,13 +176,40 @@ class _TraitState:
     state_types: list[int] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class _PendingTrait:
+    """A device trait held back until its device type is known."""
+
+    type_url: str
+    value: bytes
+    trait_label: str | None
+    state_types: tuple[int, ...]
+
+
 @dataclass
 class ProtobufObserveState:
-    """Mutable mapping state needed while decoding protobuf observe messages."""
+    """Mutable mapping state needed while decoding protobuf observe messages.
+
+    Owned by the caller and reused across observe streams: the gateway
+    re-enumerates from scratch on every reconnect, and re-learning the device
+    map each time would re-run the ordering race below on every reconnect.
+    """
 
     user_id: str | None = None
     legacy_structure_ids: dict[str, str] = field(default_factory=dict)
     device_types: dict[str, str] = field(default_factory=dict)
+    # Devices the gateway has named whose resource type this integration does
+    # not model. Their traits are dropped on sight rather than parked, so a
+    # Protect or Guard publishing every few seconds can't churn the buffers.
+    unsupported_devices: set[str] = field(default_factory=set)
+    # device_id -> {(type_url, trait_label): trait}. Traits that arrived before
+    # PeerDevicesTrait revealed the device they belong to.
+    pending_device_traits: dict[str, dict[tuple[str, str | None], _PendingTrait]] = (
+        field(default_factory=dict)
+    )
+    # structure_resource_id -> latest PeerDevicesTrait payload seen before
+    # StructureInfoTrait gave the structure a legacy id.
+    pending_peer_devices: dict[str, bytes] = field(default_factory=dict)
 
 
 def _varint(value: int) -> bytes:
@@ -359,19 +395,37 @@ def _decode_get_property(
         return None
 
     if type_url == USER_INFO_TYPE_URL:
+        if state.user_id == object_id:
+            return None
         state.user_id = object_id
-        return None
+        # Structures decoded before the user was known carry `user_id=None`,
+        # which leaves the Home/Away switch unable to build a command. Re-emit
+        # them now rather than waiting for the structure to publish again.
+        return [
+            ProtobufStructureUpdate(
+                resource_id=resource_id,
+                legacy_structure_id=legacy_structure_id,
+                user_id=object_id,
+            )
+            for resource_id, legacy_structure_id in state.legacy_structure_ids.items()
+        ]
 
     if type_url == STRUCTURE_INFO_TYPE_URL:
         legacy_id = _first_string_field(value, 1)
         legacy_structure_id = legacy_id.split(".", 1)[1] if legacy_id else None
+        updates: list[ProtobufObserveUpdate] = [
+            ProtobufStructureUpdate(
+                resource_id=object_id,
+                legacy_structure_id=legacy_structure_id,
+                user_id=state.user_id,
+            )
+        ]
         if legacy_structure_id:
             state.legacy_structure_ids[object_id] = legacy_structure_id
-        return ProtobufStructureUpdate(
-            resource_id=object_id,
-            legacy_structure_id=legacy_structure_id,
-            user_id=state.user_id,
-        )
+            # A PeerDevicesTrait that arrived first can now be resolved, which
+            # in turn releases every device trait parked behind it.
+            updates.extend(_drain_pending_peer_devices(object_id, state))
+        return updates
 
     if type_url == STRUCTURE_MODE_TYPE_URL:
         structure_mode = _first_varint_field(value, 1)
@@ -441,12 +495,17 @@ def _decode_peer_devices(
     structure_resource_id: str,
     payload: bytes,
     state: ProtobufObserveState,
-) -> list[ProtobufDeviceUpdate]:
+) -> list[ProtobufObserveUpdate]:
     legacy_structure_id = state.legacy_structure_ids.get(structure_resource_id)
     if not legacy_structure_id:
+        # StructureInfoTrait hasn't landed yet. Dropping the list here would
+        # leave every device on this structure unmapped for the life of the
+        # stream, so hold it until the structure is named.
+        _park_peer_devices(structure_resource_id, payload, state)
         return []
 
-    updates: list[ProtobufDeviceUpdate] = []
+    updates: list[ProtobufObserveUpdate] = []
+    resolved: list[str] = []
     for _, peer_device in _bytes_fields(payload, 1):
         data = _first_bytes_field(peer_device, 2)
         if not data:
@@ -457,27 +516,135 @@ def _decode_peer_devices(
         if not resource_id or not device_type:
             continue
 
+        device_id = _legacy_device_id(resource_id)
+
         prefix = BUCKET_PREFIXES.get(device_type)
         if not prefix:
+            # Now known to be a type we don't model, so stop holding — and stop
+            # accepting — traits for it.
+            if device_id not in state.unsupported_devices:
+                _LOGGER.debug(
+                    "Observe: device %s has unsupported resource type %s, "
+                    "ignoring its traits",
+                    device_id,
+                    device_type,
+                )
+            state.unsupported_devices.add(device_id)
+            state.pending_device_traits.pop(device_id, None)
             continue
 
-        device_id = _legacy_device_id(resource_id)
         state.device_types[device_id] = device_type
-        updates.append(
-            ProtobufDeviceUpdate(
-                object_key=f"{prefix}.{device_id}",
-                value={
-                    "using_protobuf": True,
-                    "device_id": device_id,
-                    "structure_id": legacy_structure_id,
-                    "current_version": _first_string_field(data, 5),
-                    "user_id": state.user_id,
-                    "protobuf_device_type": device_type,
-                },
+        resolved.append(device_id)
+        # `current_version` and `user_id` are absent when the gateway omits the
+        # firmware version, or when this trait wins the race against
+        # UserInfoTrait. Writing None would clobber a good value on the bucket.
+        value = {
+            "using_protobuf": True,
+            "device_id": device_id,
+            "structure_id": legacy_structure_id,
+            "protobuf_device_type": device_type,
+        } | {
+            key: optional
+            for key, optional in (
+                ("current_version", _first_string_field(data, 5)),
+                ("user_id", state.user_id),
             )
+            if optional is not None
+        }
+
+        updates.append(
+            ProtobufDeviceUpdate(object_key=f"{prefix}.{device_id}", value=value)
         )
 
+    for device_id in resolved:
+        updates.extend(_drain_pending_device_traits(device_id, state))
+
     return updates
+
+
+def _park_peer_devices(
+    structure_resource_id: str, payload: bytes, state: ProtobufObserveState
+) -> None:
+    """Hold a PeerDevicesTrait until its structure has a legacy id."""
+    pending = state.pending_peer_devices
+    if structure_resource_id not in pending:
+        _evict_oldest(pending, MAX_PENDING_STRUCTURES, "peer devices")
+    pending[structure_resource_id] = payload
+    _LOGGER.debug(
+        "Observe: holding peer devices for unmapped structure %s",
+        structure_resource_id,
+    )
+
+
+def _drain_pending_peer_devices(
+    structure_resource_id: str, state: ProtobufObserveState
+) -> list[ProtobufObserveUpdate]:
+    """Decode a PeerDevicesTrait held back for this structure, if any."""
+    payload = state.pending_peer_devices.pop(structure_resource_id, None)
+    if payload is None:
+        return []
+
+    _LOGGER.debug(
+        "Observe: replaying held peer devices for structure %s",
+        structure_resource_id,
+    )
+    return _decode_peer_devices(structure_resource_id, payload, state)
+
+
+def _park_device_trait(
+    state: ProtobufObserveState, device_id: str, pending: _PendingTrait
+) -> None:
+    """Hold a device trait until PeerDevicesTrait reveals the device's type.
+
+    Keyed by trait, so repeated publishes of the same trait supersede each
+    other rather than accumulating — a device can sit unmapped for the life of
+    the stream without the buffer growing.
+    """
+    parked = state.pending_device_traits.get(device_id)
+    if parked is None:
+        _evict_oldest(state.pending_device_traits, MAX_PENDING_DEVICES, "device traits")
+        parked = state.pending_device_traits.setdefault(device_id, {})
+
+    parked[(pending.type_url, pending.trait_label)] = pending
+    _LOGGER.debug(
+        "Observe: holding trait %s for unmapped device %s", pending.type_url, device_id
+    )
+
+
+def _drain_pending_device_traits(
+    device_id: str, state: ProtobufObserveState
+) -> list[ProtobufObserveUpdate]:
+    """Decode every trait held back for a device that is now mapped."""
+    parked = state.pending_device_traits.pop(device_id, None)
+    if not parked:
+        return []
+
+    _LOGGER.debug(
+        "Observe: replaying %d held trait(s) for device %s", len(parked), device_id
+    )
+    updates: list[ProtobufObserveUpdate] = []
+    for pending in parked.values():
+        update = _decode_device_property(
+            device_id,
+            pending.type_url,
+            pending.value,
+            state,
+            trait_label=pending.trait_label,
+            state_types=list(pending.state_types),
+        )
+        if update:
+            updates.append(update)
+    return updates
+
+
+def _evict_oldest(buffer: dict, limit: int, what: str) -> None:
+    """Make room for one more entry in a parking buffer, oldest first."""
+    while len(buffer) >= limit:
+        evicted, _ = next(iter(buffer.items()))
+        del buffer[evicted]
+        _LOGGER.debug(
+            "Observe: %s buffer full, dropping held entry for %s", what, evicted
+        )
 
 
 def _decode_device_property(
@@ -493,6 +660,22 @@ def _decode_device_property(
     device_type = state.device_types.get(device_id)
     prefix = BUCKET_PREFIXES.get(device_type) if device_type else None
     if not prefix:
+        # The gateway gives no ordering guarantee between PeerDevicesTrait —
+        # which is the only thing that maps a device id to a type — and the
+        # per-device traits. Discarding here used to lose the reading until the
+        # device next republished it, which for temperature is tens of minutes
+        # and for RCS settings can be hours.
+        if device_id not in state.unsupported_devices:
+            _park_device_trait(
+                state,
+                device_id,
+                _PendingTrait(
+                    type_url=type_url,
+                    value=payload,
+                    trait_label=trait_label,
+                    state_types=tuple(state_types or ()),
+                ),
+            )
         return None
 
     object_key = f"{prefix}.{device_id}"

--- a/custom_components/nest_protect/pynest/protobuf.py
+++ b/custom_components/nest_protect/pynest/protobuf.py
@@ -52,6 +52,7 @@ DEVICE_LOCATED_SETTINGS_TYPE_URL = (
     "type.nestlabs.com/nest.trait.located.DeviceLocatedSettingsTrait"
 )
 TEMPERATURE_TYPE_URL = "type.nestlabs.com/nest.trait.sensor.TemperatureTrait"
+HUMIDITY_TYPE_URL = "type.nestlabs.com/nest.trait.sensor.HumidityTrait"
 BATTERY_TYPE_URL = "type.nestlabs.com/weave.trait.power.BatteryPowerSourceTrait"
 RCS_SETTINGS_TYPE_URL = (
     "type.nestlabs.com/nest.trait.hvac.RemoteComfortSensingSettingsTrait"
@@ -96,6 +97,7 @@ OBSERVE_TRAITS = (
     "weave.trait.description.DeviceIdentityTrait",
     "nest.trait.located.DeviceLocatedSettingsTrait",
     "nest.trait.sensor.TemperatureTrait",
+    "nest.trait.sensor.HumidityTrait",
     "weave.trait.power.BatteryPowerSourceTrait",
     "nest.trait.hvac.RemoteComfortSensingSettingsTrait",
 )
@@ -429,6 +431,15 @@ def _decode_device_property(
             else TRAIT_LABEL_CURRENT_TEMPERATURE
         )
         return ProtobufDeviceUpdate(object_key=object_key, value={key: temperature})
+
+    if type_url == HUMIDITY_TYPE_URL:
+        # HumidityTrait has the same nesting as TemperatureTrait.
+        humidity = _nested_float(payload, 1, 1, 1)
+        if humidity is None:
+            return None
+        return ProtobufDeviceUpdate(
+            object_key=object_key, value={"current_humidity": humidity}
+        )
 
     if type_url == BATTERY_TYPE_URL:
         return _device_update(

--- a/custom_components/nest_protect/sensor.py
+++ b/custom_components/nest_protect/sensor.py
@@ -14,8 +14,9 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import PERCENTAGE, UnitOfTemperature
-from homeassistant.core import callback
+from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.typing import StateType
 
@@ -140,14 +141,28 @@ SENSOR_DESCRIPTIONS: list[NestProtectSensorDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         bucket_type=BucketType.DEVICE,
     ),
+    NestProtectSensorDescription(
+        key="current_humidity",
+        translation_key="current_humidity",
+        value_fn=round,
+        device_class=SensorDeviceClass.HUMIDITY,
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        bucket_type=BucketType.DEVICE,
+    ),
     # TODO Add Color Status (gray, green, yellow, red)
     # TODO Smoke Status (OK, Warning, Emergency)
     # TODO CO Status (OK, Warning, Emergency)
 ]
 
-# The thermostat's own sensor, and the effective reading it controls on — which
-# follows the selected remote comfort sensor and is what the SDM API reports.
-THERMOSTAT_SENSOR_KEYS = ("backplate_temperature", "current_temperature")
+# The thermostat's own sensor, the effective reading it controls on — which
+# follows the selected remote comfort sensor and is what the SDM API reports —
+# and its humidity.
+THERMOSTAT_SENSOR_KEYS = (
+    "backplate_temperature",
+    "current_temperature",
+    "current_humidity",
+)
 
 ACTIVE_TEMPERATURE_SENSOR_DESCRIPTION = NestProtectSensorDescription(
     key="active_temperature_sensor",
@@ -315,6 +330,50 @@ class NestThermostatActiveSensor(NestThermostatSensor):
         """Initialize with the device map, to name the selected sensor."""
         super().__init__(bucket, description, areas, client)
         self._devices = devices
+        self._sensor_unsubs: dict[str, CALLBACK_TYPE] = {}
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to this thermostat, and to the sensors it names."""
+        await super().async_added_to_hass()
+        self.async_on_remove(self._unsubscribe_sensors)
+        self._resubscribe_sensors()
+
+    @callback
+    def update_callback(self, bucket: Bucket) -> None:
+        """Handle a thermostat update, following any change of selection."""
+        super().update_callback(bucket)
+        self._resubscribe_sensors()
+
+    @callback
+    def _resubscribe_sensors(self) -> None:
+        """Track bucket updates for the sensors this entity names.
+
+        A temperature sensor's room label lands in its own `where_id` trait,
+        routinely after the selection that points at it. Without following those
+        buckets the state would keep showing the bare device id until the next
+        thermostat update happened to arrive.
+        """
+        wanted = set(self.bucket.value.get("active_rcs_sensors") or [])
+
+        for object_key in wanted - self._sensor_unsubs.keys():
+            self._sensor_unsubs[object_key] = async_dispatcher_connect(
+                self.hass, object_key, self._sensor_updated
+            )
+
+        for object_key in self._sensor_unsubs.keys() - wanted:
+            self._sensor_unsubs.pop(object_key)()
+
+    @callback
+    def _unsubscribe_sensors(self) -> None:
+        """Drop every sensor-bucket subscription."""
+        while self._sensor_unsubs:
+            _, unsub = self._sensor_unsubs.popitem()
+            unsub()
+
+    @callback
+    def _sensor_updated(self, bucket: Bucket) -> None:
+        """Re-resolve the name after a selected sensor publishes new traits."""
+        self.async_write_ha_state()
 
     @property
     def native_value(self) -> str | None:

--- a/custom_components/nest_protect/sensor.py
+++ b/custom_components/nest_protect/sensor.py
@@ -14,6 +14,8 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import PERCENTAGE, UnitOfTemperature
+from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.typing import StateType
 
@@ -21,7 +23,15 @@ from . import HomeAssistantNestProtectData
 from .const import DOMAIN
 from .entity import NestDescriptiveEntity
 from .lock import NestLockBatterySensor, subscribe_to_lock_discovery
+from .pynest.client import NestClient
 from .pynest.enums import BucketType
+from .pynest.models import Bucket
+from .pynest.protobuf import (
+    RCS_SOURCE_TYPE_BACKPLATE,
+    RCS_SOURCE_TYPE_MULTI_SENSOR,
+    RCS_SOURCE_TYPE_SINGLE_SENSOR,
+)
+from .thermostat import subscribe_to_thermostat_discovery
 
 
 def milli_volt_to_percentage(state: int):
@@ -121,10 +131,39 @@ SENSOR_DESCRIPTIONS: list[NestProtectSensorDescription] = [
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    NestProtectSensorDescription(
+        key="backplate_temperature",
+        translation_key="backplate_temperature",
+        value_fn=lambda state: round(state, 2),
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        bucket_type=BucketType.DEVICE,
+    ),
     # TODO Add Color Status (gray, green, yellow, red)
     # TODO Smoke Status (OK, Warning, Emergency)
     # TODO CO Status (OK, Warning, Emergency)
 ]
+
+# The thermostat's own sensor, and the effective reading it controls on — which
+# follows the selected remote comfort sensor and is what the SDM API reports.
+THERMOSTAT_SENSOR_KEYS = ("backplate_temperature", "current_temperature")
+
+ACTIVE_TEMPERATURE_SENSOR_DESCRIPTION = NestProtectSensorDescription(
+    key="active_temperature_sensor",
+    translation_key="active_temperature_sensor",
+    bucket_type=BucketType.DEVICE,
+)
+
+# State shown when the thermostat controls on its own backplate sensor rather
+# than on a Nest Temperature Sensor.
+THERMOSTAT_SOURCE_LABEL = "Thermostat"
+
+RCS_SOURCE_TYPE_NAMES: dict[int | None, str] = {
+    RCS_SOURCE_TYPE_BACKPLATE: "backplate",
+    RCS_SOURCE_TYPE_SINGLE_SENSOR: "single_sensor",
+    RCS_SOURCE_TYPE_MULTI_SENSOR: "multi_sensor",
+}
 
 
 async def async_setup_entry(hass, entry, async_add_devices):
@@ -134,6 +173,10 @@ async def async_setup_entry(hass, entry, async_add_devices):
     entities: list[NestProtectSensor] = []
 
     for device in data.devices.values():
+        # Thermostats come in through protobuf discovery below.
+        if device.type == BucketType.DEVICE:
+            continue
+
         supported_keys: dict[str, NestProtectSensorDescription] = {
             description.key: description
             for description in SENSOR_DESCRIPTIONS
@@ -151,6 +194,33 @@ async def async_setup_entry(hass, entry, async_add_devices):
     # Battery sensors for any discovered Nest x Yale locks.
     subscribe_to_lock_discovery(hass, entry, async_add_devices, NestLockBatterySensor)
 
+    # Temperature sensors for any thermostat seen on the protobuf stream.
+    thermostat_descriptions = [
+        description
+        for description in SENSOR_DESCRIPTIONS
+        if description.key in THERMOSTAT_SENSOR_KEYS
+    ]
+    subscribe_to_thermostat_discovery(
+        hass,
+        entry,
+        async_add_devices,
+        lambda bucket: (
+            [
+                NestThermostatSensor(bucket, description, data.areas, data.client)
+                for description in thermostat_descriptions
+            ]
+            + [
+                NestThermostatActiveSensor(
+                    bucket,
+                    ACTIVE_TEMPERATURE_SENSOR_DESCRIPTION,
+                    data.areas,
+                    data.client,
+                    data.devices,
+                )
+            ]
+        ),
+    )
+
 
 class NestProtectSensor(NestDescriptiveEntity, SensorEntity):
     """Representation of a Nest Protect Sensor."""
@@ -162,7 +232,124 @@ class NestProtectSensor(NestDescriptiveEntity, SensorEntity):
         """Return the state of the sensor."""
         state = self.bucket.value.get(self.entity_description.key)
 
+        if state is None:
+            return None
+
         if self.entity_description.value_fn:
             return self.entity_description.value_fn(state)
 
         return state
+
+
+class NestThermostatSensor(NestProtectSensor):
+    """Temperature sensor on a thermostat discovered via the protobuf stream."""
+
+    def __init__(
+        self,
+        bucket: Bucket,
+        description: NestProtectSensorDescription,
+        areas: dict[str, str],
+        client: NestClient,
+    ) -> None:
+        """Initialize, keeping the area map to resolve late `where_id` traits."""
+        super().__init__(bucket, description, areas, client)
+        self._areas = areas
+        self._identity = self._identity_snapshot()
+
+    def _identity_snapshot(self) -> tuple:
+        """Snapshot the bucket values that feed DeviceInfo.
+
+        The observe loop mutates the bucket in place, so the previous values have
+        to be remembered here rather than read back off the incoming bucket.
+        """
+        return tuple(
+            self.bucket.value.get(key)
+            for key in ("model", "current_version", "where_id")
+        )
+
+    @callback
+    def update_callback(self, bucket: Bucket) -> None:
+        """Update the entity, refreshing device details that arrive late.
+
+        `DeviceInfo` is only read when the entity is added, but the model,
+        firmware version and room label arrive in traits published after the one
+        that first reveals the thermostat. Those have to be written to the
+        registry directly, the same way `lock.py` does it.
+        """
+        self.area = self._areas.get(bucket.value.get("where_id"))
+        super().update_callback(bucket)
+
+        if (identity := self._identity_snapshot()) == self._identity:
+            return
+        self._identity = identity
+
+        if not (device_entry := self.device_entry):
+            return
+
+        if (device_info := self.generate_device_info()) is None:
+            return
+
+        dr.async_get(self.hass).async_update_device(
+            device_entry.id,
+            name=device_info.get("name"),
+            model=device_info.get("model"),
+            sw_version=device_info.get("sw_version"),
+        )
+
+
+class NestThermostatActiveSensor(NestThermostatSensor):
+    """Which temperature source the thermostat is currently controlling on.
+
+    Read-only. Google's SDM API offers no equivalent: it reports the effective
+    temperature without saying where it comes from.
+    """
+
+    def __init__(
+        self,
+        bucket: Bucket,
+        description: NestProtectSensorDescription,
+        areas: dict[str, str],
+        client: NestClient,
+        devices: dict[str, Bucket],
+    ) -> None:
+        """Initialize with the device map, to name the selected sensor."""
+        super().__init__(bucket, description, areas, client)
+        self._devices = devices
+
+    @property
+    def native_value(self) -> str | None:
+        """Return a human-readable name for the active temperature source."""
+        source_type = self.bucket.value.get("rcs_source_type")
+        active = self.bucket.value.get("active_rcs_sensors") or []
+
+        if source_type == RCS_SOURCE_TYPE_BACKPLATE:
+            return THERMOSTAT_SOURCE_LABEL
+
+        if source_type == RCS_SOURCE_TYPE_SINGLE_SENSOR and active:
+            return self._sensor_label(active[0])
+
+        if source_type == RCS_SOURCE_TYPE_MULTI_SENSOR and active:
+            return ", ".join(sorted(self._sensor_label(key) for key in active))
+
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose the raw selection, for automations and troubleshooting."""
+        source_type = self.bucket.value.get("rcs_source_type")
+
+        return {
+            "source_type": RCS_SOURCE_TYPE_NAMES.get(source_type, "unknown"),
+            "active_sensors": self.bucket.value.get("active_rcs_sensors") or [],
+            "associated_sensors": self.bucket.value.get("associated_rcs_sensors") or [],
+        }
+
+    def _sensor_label(self, object_key: str) -> str:
+        """Name a temperature sensor by its own label, else its room."""
+        sensor = self._devices.get(object_key)
+        label = sensor and (
+            sensor.value.get("description")
+            or self._areas.get(sensor.value.get("where_id"))
+        )
+
+        return label or object_key.removeprefix("kryptonite.")

--- a/custom_components/nest_protect/sensor.py
+++ b/custom_components/nest_protect/sensor.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.typing import StateType
 
 from . import HomeAssistantNestProtectData
 from .const import DOMAIN
-from .entity import NestDescriptiveEntity
+from .entity import NestDescriptiveEntity, resolve_area
 from .lock import NestLockBatterySensor, subscribe_to_lock_discovery
 from .pynest.client import NestClient
 from .pynest.enums import BucketType
@@ -279,7 +279,7 @@ class NestThermostatSensor(NestProtectSensor):
         """
         return tuple(
             self.bucket.value.get(key)
-            for key in ("model", "current_version", "where_id")
+            for key in ("model", "current_version", "where_id", "where_label")
         )
 
     @callback
@@ -291,7 +291,7 @@ class NestThermostatSensor(NestProtectSensor):
         that first reveals the thermostat. Those have to be written to the
         registry directly, the same way `lock.py` does it.
         """
-        self.area = self._areas.get(bucket.value.get("where_id"))
+        self.area = resolve_area(bucket.value, self._areas)
         super().update_callback(bucket)
 
         if (identity := self._identity_snapshot()) == self._identity:
@@ -407,8 +407,7 @@ class NestThermostatActiveSensor(NestThermostatSensor):
         """Name a temperature sensor by its own label, else its room."""
         sensor = self._devices.get(object_key)
         label = sensor and (
-            sensor.value.get("description")
-            or self._areas.get(sensor.value.get("where_id"))
+            sensor.value.get("description") or resolve_area(sensor.value, self._areas)
         )
 
         return label or object_key.removeprefix("kryptonite.")

--- a/custom_components/nest_protect/strings.json
+++ b/custom_components/nest_protect/strings.json
@@ -116,6 +116,12 @@
       },
       "current_temperature": {
         "name": "Temperature"
+      },
+      "backplate_temperature": {
+        "name": "Backplate temperature"
+      },
+      "active_temperature_sensor": {
+        "name": "Active temperature sensor"
       }
     },
     "select": {

--- a/custom_components/nest_protect/strings.json
+++ b/custom_components/nest_protect/strings.json
@@ -120,6 +120,9 @@
       "backplate_temperature": {
         "name": "Backplate temperature"
       },
+      "current_humidity": {
+        "name": "Humidity"
+      },
       "active_temperature_sensor": {
         "name": "Active temperature sensor"
       }

--- a/custom_components/nest_protect/switch.py
+++ b/custom_components/nest_protect/switch.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
-from homeassistant.helpers.entity import EntityCategory
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 
 from . import HomeAssistantNestProtectData
-from .const import DOMAIN, LOGGER
+from .const import ATTRIBUTION, DOMAIN, LOGGER
 from .entity import NestUpdatableEntity
+from .pynest.models import Bucket
 
 
 @dataclass
@@ -65,7 +69,7 @@ async def async_setup_entry(hass, entry, async_add_devices):
     """Set up the Nest Protect sensors from a config entry."""
 
     data: HomeAssistantNestProtectData = hass.data[DOMAIN][entry.entry_id]
-    entities: list[NestProtectSwitch] = []
+    entities: list[SwitchEntity] = []
 
     supported_keys: dict[str, NestProtectSwitchDescription] = {
         description.key: description for description in SWITCH_DESCRIPTIONS
@@ -83,6 +87,15 @@ async def async_setup_entry(hass, entry, async_add_devices):
                         data.session_manager,
                     )
                 )
+
+    for structure in data.structures.values():
+        entities.append(
+            NestStructureHomeAwaySwitch(
+                structure,
+                data.client,
+                data.session_manager,
+            )
+        )
 
     async_add_devices(entities)
 
@@ -126,3 +139,91 @@ class NestProtectSwitch(NestUpdatableEntity, SwitchEntity):
 
         result = await self._async_update_objects(objects)
         LOGGER.debug(result)
+
+
+class NestStructureHomeAwaySwitch(SwitchEntity):
+    """Representation of a Nest structure Home/Away switch."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_attribution = ATTRIBUTION
+    _attr_translation_key = "home_away"
+
+    def __init__(self, bucket: Bucket, client, session_manager) -> None:
+        """Initialize the structure Home/Away switch."""
+        self.bucket = bucket
+        self.client = client
+        self.session_manager = session_manager
+        self._attr_unique_id = f"{bucket.object_key}-home_away"
+        self._attr_device_info = self._generate_device_info()
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if the structure is home."""
+        away = self.bucket.value.get("away")
+        if away is None:
+            return None
+        return not away
+
+    def _generate_device_info(self) -> DeviceInfo:
+        structure_id = self.bucket.object_key.split(".", 1)[1]
+        name = self.bucket.value.get("name") or "Nest Home"
+        return DeviceInfo(
+            identifiers={(DOMAIN, structure_id)},
+            name=name,
+            manufacturer="Google",
+            configuration_url=f"https://home.nest.com/home/{structure_id}",
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity is added to register update signal handler."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, self.bucket.object_key, self.update_callback
+            )
+        )
+
+    @callback
+    def update_callback(self, bucket: Bucket):
+        """Update the entity state."""
+        self.bucket = bucket
+        self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Set the structure to Home."""
+        await self._async_set_home(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Set the structure to Away."""
+        await self._async_set_home(False)
+
+    async def _async_set_home(self, home: bool) -> None:
+        await self.session_manager.ensure_session()
+
+        if self.bucket.value.get("new_structure_id") and self.bucket.value.get("user_id"):
+            await self.client.send_structure_mode_command(
+                self.client.nest_session.access_token,
+                f"STRUCTURE_{self.bucket.value['new_structure_id']}",
+                self.bucket.value["user_id"],
+                home,
+            )
+        else:
+            await self.client.update_objects(
+                self.client.nest_session.access_token,
+                self.client.nest_session.userid,
+                self.client.transport_url,
+                [
+                    {
+                        "object_key": self.bucket.object_key,
+                        "op": "MERGE",
+                        "value": {
+                            "away": not home,
+                            "away_timestamp": int(time.time()),
+                            "away_setter": 0,
+                        },
+                    }
+                ],
+            )
+
+        self.bucket.value["away"] = not home
+        self.async_write_ha_state()

--- a/custom_components/nest_protect/switch.py
+++ b/custom_components/nest_protect/switch.py
@@ -200,7 +200,9 @@ class NestStructureHomeAwaySwitch(SwitchEntity):
     async def _async_set_home(self, home: bool) -> None:
         await self.session_manager.ensure_session()
 
-        if self.bucket.value.get("new_structure_id") and self.bucket.value.get("user_id"):
+        if self.bucket.value.get("new_structure_id") and self.bucket.value.get(
+            "user_id"
+        ):
             await self.client.send_structure_mode_command(
                 self.client.nest_session.access_token,
                 f"STRUCTURE_{self.bucket.value['new_structure_id']}",

--- a/custom_components/nest_protect/thermostat.py
+++ b/custom_components/nest_protect/thermostat.py
@@ -22,6 +22,31 @@ from .pynest.models import Bucket
 THERMOSTAT_SIGNAL_PREFIX = "nest_protect_thermostat_"
 THERMOSTAT_BUCKET_PREFIX = "device."
 
+# Identity worth caching across reloads. Readings are deliberately excluded:
+# they arrive within seconds of the stream reconnecting, and a restored
+# temperature would be indistinguishable from a live one.
+THERMOSTAT_CACHE_KEYS = frozenset(
+    {
+        "using_protobuf",
+        "device_id",
+        "structure_id",
+        "protobuf_device_type",
+        "serial_number",
+        "model",
+        "current_version",
+        "where_id",
+    }
+)
+
+
+def thermostat_cache_entry(bucket: Bucket) -> dict:
+    """Reduce a thermostat bucket to the fields worth persisting."""
+    return {
+        key: value
+        for key, value in bucket.value.items()
+        if key in THERMOSTAT_CACHE_KEYS
+    }
+
 
 def thermostat_discovery_signal(entry_id: str) -> str:
     """Dispatcher signal for newly-discovered thermostats on a config entry."""

--- a/custom_components/nest_protect/thermostat.py
+++ b/custom_components/nest_protect/thermostat.py
@@ -35,6 +35,7 @@ THERMOSTAT_CACHE_KEYS = frozenset(
         "model",
         "current_version",
         "where_id",
+        "where_label",
     }
 )
 

--- a/custom_components/nest_protect/thermostat.py
+++ b/custom_components/nest_protect/thermostat.py
@@ -1,0 +1,75 @@
+"""Discovery helpers for Nest thermostats seen on the protobuf observe stream.
+
+Thermostats have no legacy REST bucket here — `NEST_REQUEST` never asks for the
+`device`/`shared` types — so they are discovered from the protobuf stream after
+the platforms have already been set up. This mirrors the dispatcher-based
+discovery `lock.py` uses for Nest x Yale locks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .pynest.models import Bucket
+
+THERMOSTAT_SIGNAL_PREFIX = "nest_protect_thermostat_"
+THERMOSTAT_BUCKET_PREFIX = "device."
+
+
+def thermostat_discovery_signal(entry_id: str) -> str:
+    """Dispatcher signal for newly-discovered thermostats on a config entry."""
+    return f"{THERMOSTAT_SIGNAL_PREFIX}discover_{entry_id}"
+
+
+def is_discoverable_thermostat(bucket: Bucket) -> bool:
+    """Check whether a bucket is a thermostat that is ready to be added.
+
+    The serial number arrives with `DeviceIdentityTrait`, a moment after the
+    `PeerDevicesTrait` that first reveals the device. Waiting for it means the
+    Home Assistant device is registered with its real identifier, model and room
+    rather than a placeholder, since `DeviceInfo` is only read once.
+    """
+    return bucket.object_key.startswith(THERMOSTAT_BUCKET_PREFIX) and bool(
+        bucket.value.get("serial_number")
+    )
+
+
+def subscribe_to_thermostat_discovery(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+    factory: Callable[[Bucket], Iterable[Entity]],
+) -> None:
+    """Wire one `async_add_entities` callback into thermostat discovery.
+
+    `factory(bucket)` builds the entities for one newly-seen thermostat.
+    Thermostats already discovered before this platform set up are replayed
+    immediately.
+    """
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    known: set[str] = set()
+
+    @callback
+    def _on_thermostat_discovered(bucket: Bucket) -> None:
+        if bucket.object_key in known:
+            return
+        known.add(bucket.object_key)
+        if new_entities := list(factory(bucket)):
+            async_add_entities(new_entities)
+
+    entry.async_on_unload(
+        async_dispatcher_connect(
+            hass, thermostat_discovery_signal(entry.entry_id), _on_thermostat_discovered
+        )
+    )
+
+    for bucket in list(entry_data.devices.values()):
+        if is_discoverable_thermostat(bucket):
+            _on_thermostat_discovered(bucket)

--- a/custom_components/nest_protect/translations/en.json
+++ b/custom_components/nest_protect/translations/en.json
@@ -140,6 +140,9 @@
       },
       "steam_detection_enable": {
         "name": "Steam check"
+      },
+      "home_away": {
+        "name": "Home occupied"
       }
     }
   }

--- a/custom_components/nest_protect/translations/en.json
+++ b/custom_components/nest_protect/translations/en.json
@@ -116,6 +116,12 @@
       },
       "current_temperature": {
         "name": "Temperature"
+      },
+      "backplate_temperature": {
+        "name": "Backplate temperature"
+      },
+      "active_temperature_sensor": {
+        "name": "Active temperature sensor"
       }
     },
     "select": {

--- a/custom_components/nest_protect/translations/en.json
+++ b/custom_components/nest_protect/translations/en.json
@@ -120,6 +120,9 @@
       "backplate_temperature": {
         "name": "Backplate temperature"
       },
+      "current_humidity": {
+        "name": "Humidity"
+      },
       "active_temperature_sensor": {
         "name": "Active temperature sensor"
       }

--- a/custom_components/nest_protect/translations/nl.json
+++ b/custom_components/nest_protect/translations/nl.json
@@ -140,6 +140,9 @@
       },
       "steam_detection_enable": {
         "name": "Stoomcontrole"
+      },
+      "home_away": {
+        "name": "Thuis bezet"
       }
     }
   }

--- a/custom_components/nest_protect/translations/nl.json
+++ b/custom_components/nest_protect/translations/nl.json
@@ -116,6 +116,12 @@
       },
       "current_temperature": {
         "name": "Temperatuur"
+      },
+      "backplate_temperature": {
+        "name": "Temperatuur achterplaat"
+      },
+      "active_temperature_sensor": {
+        "name": "Actieve temperatuursensor"
       }
     },
     "select": {

--- a/custom_components/nest_protect/translations/nl.json
+++ b/custom_components/nest_protect/translations/nl.json
@@ -120,6 +120,9 @@
       "backplate_temperature": {
         "name": "Temperatuur achterplaat"
       },
+      "current_humidity": {
+        "name": "Luchtvochtigheid"
+      },
       "active_temperature_sensor": {
         "name": "Actieve temperatuursensor"
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 name = "ha-nest-protect"
 version = "0.4.2"
 requires-python = ">=3.14.2"
+dependencies = [
+    "httpx[http2]>=0.28.1",
+]
 
 [dependency-groups]
 dev = [

--- a/tests/pynest/test_client.py
+++ b/tests/pynest/test_client.py
@@ -7,7 +7,7 @@ from aiohttp import ClientSession, web
 from aiohttp.test_utils import TestServer
 
 from custom_components.nest_protect.pynest.client import NestClient, merge_cookies
-from custom_components.nest_protect.pynest.const import NEST_REQUEST
+from custom_components.nest_protect.pynest.const import NEST_REQUEST, SEND_COMMAND_PATH
 
 
 @pytest.mark.enable_socket
@@ -210,3 +210,36 @@ def test_merge_cookies_empty_new():
     original = "SID=old; HSID=val"
     result = merge_cookies(original, {})
     assert result == original
+
+
+@pytest.mark.enable_socket
+async def test_send_structure_mode_command(socket_enabled):
+    """Test sending a protobuf structure mode command."""
+
+    async def command_response(request):
+        body = await request.read()
+        request.app["request"].append((request.headers, body))
+        return web.Response(body=b"ok", content_type="application/x-protobuf")
+
+    app = web.Application()
+    app.router.add_post(SEND_COMMAND_PATH, command_response)
+    app["request"] = []
+
+    async with TestServer(app) as server, ClientSession() as session:
+        nest_client = NestClient(session)
+        base = str(server.make_url("")).rstrip("/")
+        with patch.object(nest_client.environment, "grpc_host", base):
+            result = await nest_client.send_structure_mode_command(
+                "access-token",
+                "STRUCTURE_abc",
+                "USER_123",
+                False,
+            )
+
+    assert result == b"ok"
+    assert len(app["request"]) == 1
+    headers, body = app["request"][0]
+    assert headers.get("Authorization") == "Basic access-token"
+    assert headers.get("Content-Type") == "application/x-protobuf"
+    assert b"STRUCTURE_abc" in body
+    assert b"structure_mode" in body

--- a/tests/pynest/test_client.py
+++ b/tests/pynest/test_client.py
@@ -7,7 +7,7 @@ from aiohttp import ClientSession, web
 from aiohttp.test_utils import TestServer
 
 from custom_components.nest_protect.pynest.client import NestClient, merge_cookies
-from custom_components.nest_protect.pynest.const import NEST_REQUEST
+from custom_components.nest_protect.pynest.const import NEST_REQUEST, SEND_COMMAND_PATH
 
 
 @pytest.mark.enable_socket
@@ -211,3 +211,36 @@ def test_merge_cookies_empty_new():
     original = "SID=old; HSID=val"
     result = merge_cookies(original, {})
     assert result == original
+
+
+@pytest.mark.enable_socket
+async def test_send_structure_mode_command(socket_enabled):
+    """Test sending a protobuf structure mode command."""
+
+    async def command_response(request):
+        body = await request.read()
+        request.app["request"].append((request.headers, body))
+        return web.Response(body=b"ok", content_type="application/x-protobuf")
+
+    app = web.Application()
+    app.router.add_post(SEND_COMMAND_PATH, command_response)
+    app["request"] = []
+
+    async with TestServer(app) as server, ClientSession() as session:
+        nest_client = NestClient(session)
+        base = str(server.make_url("")).rstrip("/")
+        with patch.object(nest_client.environment, "grpc_host", base):
+            result = await nest_client.send_structure_mode_command(
+                "access-token",
+                "STRUCTURE_abc",
+                "USER_123",
+                False,
+            )
+
+    assert result == b"ok"
+    assert len(app["request"]) == 1
+    headers, body = app["request"][0]
+    assert headers.get("Authorization") == "Basic access-token"
+    assert headers.get("Content-Type") == "application/x-protobuf"
+    assert b"STRUCTURE_abc" in body
+    assert b"structure_mode" in body

--- a/tests/pynest/test_protobuf.py
+++ b/tests/pynest/test_protobuf.py
@@ -1,0 +1,224 @@
+"""Tests for small protobuf encoders."""
+
+from struct import pack
+
+from custom_components.nest_protect.pynest.protobuf import (
+    BATTERY_TYPE_URL,
+    DEVICE_IDENTITY_TYPE_URL,
+    DEVICE_LOCATED_SETTINGS_TYPE_URL,
+    LIVENESS_TYPE_URL,
+    NEST_KRYPTONITE_RESOURCE,
+    PEER_DEVICES_TYPE_URL,
+    STRUCTURE_INFO_TYPE_URL,
+    STRUCTURE_MODE_CHANGE_TYPE_URL,
+    STRUCTURE_MODE_TYPE_URL,
+    TEMPERATURE_TYPE_URL,
+    USER_INFO_TYPE_URL,
+    ProtobufDeviceUpdate,
+    ProtobufObserveState,
+    _field_bytes,
+    _field_string,
+    _field_varint,
+    decode_observe_stream_frames,
+    decode_structure_updates,
+    encode_observe_request,
+    encode_structure_mode_change_request,
+    encode_structure_mode_resource_command_request,
+)
+
+
+def test_encode_structure_mode_change_request_home():
+    """Test encoding StructureModeChangeRequest for Home."""
+    result = encode_structure_mode_change_request(home=True, user_id="USER_123")
+
+    assert result == b"\x08\x01\x10\x01\x1a\n\n\x08USER_123"
+
+
+def test_encode_structure_mode_change_request_away():
+    """Test encoding StructureModeChangeRequest for Away."""
+    result = encode_structure_mode_change_request(home=False, user_id="USER_123")
+
+    assert result == b"\x08\x02\x10\x01\x1a\n\n\x08USER_123"
+
+
+def test_encode_structure_mode_resource_command_request():
+    """Test encoding ResourceCommandRequest shape."""
+    result = encode_structure_mode_resource_command_request(
+        structure_resource_id="STRUCTURE_abc",
+        home=False,
+        user_id="USER_123",
+    )
+
+    assert b"STRUCTURE_abc" in result
+    assert b"structure_mode" in result
+    assert STRUCTURE_MODE_CHANGE_TYPE_URL.encode() in result
+    assert b"\x08\x02\x10\x01\x1a\n\n\x08USER_123" in result
+
+
+def test_encode_observe_request_asks_for_home_away_traits():
+    """Test encoding the observe request trait list."""
+    result = encode_observe_request()
+
+    assert b"nest.trait.user.UserInfoTrait" in result
+    assert b"nest.trait.structure.StructureInfoTrait" in result
+    assert b"nest.trait.occupancy.StructureModeTrait" in result
+    assert b"weave.trait.peerdevices.PeerDevicesTrait" in result
+    assert b"nest.trait.sensor.TemperatureTrait" in result
+
+
+def test_decode_observe_stream_frames():
+    """Test splitting observe stream frames across chunks."""
+    first = _field_bytes(1, b"first")
+    second = _field_bytes(1, b"second")
+    payload = first + second
+
+    frames, pending = decode_observe_stream_frames(payload[:-2])
+    assert frames == [first]
+    assert pending
+
+    frames, pending = decode_observe_stream_frames(pending + payload[-2:])
+    assert frames == [second]
+    assert pending == b""
+
+
+def test_decode_structure_updates_maps_structure_and_mode():
+    """Test decoding Homebridge-equivalent structure info and mode traits."""
+    state = ProtobufObserveState()
+    payload = _stream_body(
+        _get_property(
+            "USER_123",
+            USER_INFO_TYPE_URL,
+            _field_string(1, "user.legacy"),
+        ),
+        _get_property(
+            "STRUCTURE_new",
+            STRUCTURE_INFO_TYPE_URL,
+            _field_string(1, "structure.legacy"),
+        ),
+        _get_property(
+            "STRUCTURE_new",
+            STRUCTURE_MODE_TYPE_URL,
+            _field_varint(1, 2),
+        ),
+    )
+
+    updates = decode_structure_updates(payload, state)
+
+    assert updates[0].resource_id == "STRUCTURE_new"
+    assert updates[0].legacy_structure_id == "legacy"
+    assert updates[0].user_id == "USER_123"
+    assert updates[0].away is None
+    assert updates[1].resource_id == "STRUCTURE_new"
+    assert updates[1].legacy_structure_id == "legacy"
+    assert updates[1].user_id == "USER_123"
+    assert updates[1].away is True
+
+
+def test_decode_structure_updates_home_mode():
+    """Test decoding structure mode Home."""
+    state = ProtobufObserveState(
+        user_id="USER_123",
+        legacy_structure_ids={"STRUCTURE_new": "legacy"},
+    )
+    payload = _stream_body(
+        _get_property(
+            "STRUCTURE_new",
+            STRUCTURE_MODE_TYPE_URL,
+            _field_varint(1, 1),
+        )
+    )
+
+    updates = decode_structure_updates(payload, state)
+
+    assert updates[0].away is False
+
+
+def test_decode_kryptonite_peer_devices_and_traits():
+    """Test decoding Homebridge-equivalent Kryptonite protobuf traits."""
+    state = ProtobufObserveState(user_id="USER_123")
+    payload = _stream_body(
+        _get_property(
+            "STRUCTURE_new",
+            STRUCTURE_INFO_TYPE_URL,
+            _field_string(1, "structure.legacy"),
+        ),
+        _get_property(
+            "STRUCTURE_new",
+            PEER_DEVICES_TYPE_URL,
+            _field_bytes(
+                1,
+                _field_bytes(
+                    2,
+                    _field_bytes(1, _field_string(1, "DEVICE_18B430"))
+                    + _field_bytes(2, _field_string(1, NEST_KRYPTONITE_RESOURCE))
+                    + _field_string(5, "1.2.3"),
+                ),
+            ),
+        ),
+        _get_property(
+            "18B430",
+            TEMPERATURE_TYPE_URL,
+            _field_bytes(1, _field_bytes(1, _field_float(1, 21.5))),
+        ),
+        _get_property(
+            "18B430",
+            DEVICE_IDENTITY_TYPE_URL,
+            _field_bytes(4, _field_string(1, "Nest Temperature Sensor"))
+            + _field_string(6, "serial")
+            + _field_string(7, "1.2.4"),
+        ),
+        _get_property(
+            "18B430",
+            DEVICE_LOCATED_SETTINGS_TYPE_URL,
+            _field_bytes(2, _field_string(1, "where-1"))
+            + _field_bytes(4, _field_varint(1, 4)),
+        ),
+        _get_property(
+            "18B430",
+            LIVENESS_TYPE_URL,
+            _field_varint(1, 1),
+        ),
+        _get_property(
+            "18B430",
+            BATTERY_TYPE_URL,
+            _field_varint(32, 1)
+            + _field_bytes(33, _field_bytes(1, _field_float(1, 87.5))),
+        ),
+    )
+
+    updates = decode_structure_updates(payload, state)
+    device_updates = [update for update in updates if isinstance(update, ProtobufDeviceUpdate)]
+
+    assert device_updates[0].object_key == "kryptonite.18B430"
+    assert device_updates[0].value == {
+        "using_protobuf": True,
+        "device_id": "18B430",
+        "structure_id": "legacy",
+        "current_version": "1.2.3",
+        "user_id": "USER_123",
+        "protobuf_device_type": NEST_KRYPTONITE_RESOURCE,
+    }
+    assert device_updates[1].value["current_temperature"] == 21.5
+    assert device_updates[2].value == {
+        "model": "Nest Temperature Sensor",
+        "serial_number": "serial",
+        "current_version": "1.2.4",
+    }
+    assert device_updates[3].value == {"where_id": "where-1", "fixture_type": 4}
+    assert device_updates[4].value == {"is_online": True}
+    assert device_updates[5].value == {"battery_status": 1, "battery_level": 87.5}
+
+
+def _stream_body(*get_properties: bytes) -> bytes:
+    return _field_bytes(1, b"".join(_field_bytes(3, get) for get in get_properties))
+
+
+def _get_property(resource_id: str, type_url: str, value: bytes) -> bytes:
+    object_id = _field_string(1, resource_id)
+    any_payload = _field_string(1, type_url) + _field_bytes(2, value)
+    indirect = _field_bytes(1, any_payload)
+    return _field_bytes(1, object_id) + _field_bytes(3, indirect)
+
+
+def _field_float(field_number: int, value: float) -> bytes:
+    return bytes([(field_number << 3) | 5]) + pack("<f", value)

--- a/tests/pynest/test_protobuf.py
+++ b/tests/pynest/test_protobuf.py
@@ -187,7 +187,9 @@ def test_decode_kryptonite_peer_devices_and_traits():
     )
 
     updates = decode_structure_updates(payload, state)
-    device_updates = [update for update in updates if isinstance(update, ProtobufDeviceUpdate)]
+    device_updates = [
+        update for update in updates if isinstance(update, ProtobufDeviceUpdate)
+    ]
 
     assert device_updates[0].object_key == "kryptonite.18B430"
     assert device_updates[0].value == {

--- a/tests/pynest/test_protobuf.py
+++ b/tests/pynest/test_protobuf.py
@@ -87,6 +87,36 @@ def test_decode_observe_stream_frames():
     assert pending == b""
 
 
+def test_decode_observe_stream_frames_keeps_a_split_varint():
+    """Test a length prefix split across chunks is not treated as a desync."""
+    # Field 1, length 200 -> a two-byte varint length the first chunk cuts.
+    frame = _field_bytes(1, b"x" * 200)
+
+    frames, pending = decode_observe_stream_frames(frame[:2])
+    assert frames == []
+    assert pending == frame[:2]
+
+    frames, pending = decode_observe_stream_frames(pending + frame[2:])
+    assert frames == [frame]
+    assert pending == b""
+
+
+def test_decode_observe_stream_frames_resyncs_on_bad_wire_type():
+    """Test unparseable bytes are dropped rather than poisoning every chunk.
+
+    Keeping them meant the parser could never resynchronise, silently wedging
+    the observe stream until it reconnected.
+    """
+    good = _field_bytes(1, b"first")
+    # Field 1, wire type 0 (varint) — never emitted at StreamBody level.
+    garbage = _field_varint(1, 7)
+
+    frames, pending = decode_observe_stream_frames(good + garbage)
+
+    assert frames == [good]
+    assert pending == b""
+
+
 def test_decode_structure_updates_maps_structure_and_mode():
     """Test decoding Homebridge-equivalent structure info and mode traits."""
     state = ProtobufObserveState()
@@ -176,8 +206,12 @@ def test_decode_kryptonite_peer_devices_and_traits():
         _get_property(
             "18B430",
             DEVICE_LOCATED_SETTINGS_TYPE_URL,
-            _field_bytes(2, _field_string(1, "where-1"))
-            + _field_bytes(4, _field_varint(1, 4)),
+            _located_settings(
+                annotation_rid="ANNOTATION_BEDROOM",
+                label="Kids room",
+                legacy_uuid="where-1",
+                fixture_type=4,
+            ),
         ),
         _get_property(
             "18B430",
@@ -212,7 +246,12 @@ def test_decode_kryptonite_peer_devices_and_traits():
         "serial_number": "serial",
         "current_version": "1.2.4",
     }
-    assert device_updates[3].value == {"where_id": "where-1", "fixture_type": 4}
+    assert device_updates[3].value == {
+        "where_id": "where-1",
+        "where_label": "Kids room",
+        "where_annotation_rid": "ANNOTATION_BEDROOM",
+        "fixture_type": 4,
+    }
     assert device_updates[4].value == {"is_online": True}
     assert device_updates[5].value == {"battery_status": 1, "battery_level": 87.5}
 
@@ -301,6 +340,72 @@ def test_decode_thermostat_humidity():
 
     assert updates[0].object_key == "device.09AB12"
     assert updates[0].value == {"current_humidity": 43.5}
+
+
+def test_decode_thermostat_humidity_separates_backplate_from_current():
+    """Test the paired humidity traits do not overwrite each other."""
+    state = ProtobufObserveState(device_types={"09AB12": THERMOSTAT_RESOURCE})
+    payload = _stream_body(
+        _get_property(
+            "09AB12",
+            HUMIDITY_TYPE_URL,
+            _field_bytes(1, _field_bytes(1, _field_float(1, 43.5))),
+            trait_label="backplate_humidity",
+        ),
+        _get_property(
+            "09AB12",
+            HUMIDITY_TYPE_URL,
+            _field_bytes(1, _field_bytes(1, _field_float(1, 61.0))),
+            trait_label="current_humidity",
+        ),
+    )
+
+    updates = decode_structure_updates(payload, state)
+
+    assert updates[0].value == {"backplate_humidity": 43.5}
+    assert updates[1].value == {"current_humidity": 61.0}
+
+
+def test_decode_ignores_unknown_sensor_trait_labels():
+    """Test an unrecognised label cannot overwrite the ambient reading."""
+    state = ProtobufObserveState(device_types={"09AB12": THERMOSTAT_RESOURCE})
+    payload = _stream_body(
+        _get_property(
+            "09AB12",
+            TEMPERATURE_TYPE_URL,
+            _field_bytes(1, _field_bytes(1, _field_float(1, 21.5))),
+            trait_label="some_future_temperature",
+        ),
+        _get_property(
+            "09AB12",
+            HUMIDITY_TYPE_URL,
+            _field_bytes(1, _field_bytes(1, _field_float(1, 43.5))),
+            trait_label="some_future_humidity",
+        ),
+    )
+
+    assert decode_structure_updates(payload, state) == []
+
+
+def test_decode_located_settings_keeps_legacy_uuid_out_of_annotation_rid():
+    """Test only whereLegacyUuid is written to where_id.
+
+    The annotation rid is a protobuf-only identifier; writing it to `where_id`
+    made the room lookup miss and the label fall back to the raw device id.
+    """
+    state = ProtobufObserveState(device_types={"18B430": NEST_KRYPTONITE_RESOURCE})
+    payload = _stream_body(
+        _get_property(
+            "18B430",
+            DEVICE_LOCATED_SETTINGS_TYPE_URL,
+            _located_settings(annotation_rid="ANNOTATION_BEDROOM"),
+        )
+    )
+
+    updates = decode_structure_updates(payload, state)
+
+    assert updates[0].value == {"where_annotation_rid": "ANNOTATION_BEDROOM"}
+    assert "where_id" not in updates[0].value
 
 
 def test_decode_rcs_settings_single_sensor():
@@ -443,3 +548,28 @@ def _get_property(
 
 def _field_float(field_number: int, value: float) -> bytes:
     return bytes([(field_number << 3) | 5]) + pack("<f", value)
+
+
+def _located_settings(
+    *,
+    annotation_rid: str | None = None,
+    label: str | None = None,
+    legacy_uuid: str | None = None,
+    fixture_type: int | None = None,
+) -> bytes:
+    """Build a DeviceLocatedSettingsTrait payload.
+
+    Field numbers mirror protobuf_gen/nest/trait/located_pb2: whereAnnotationRid
+    is a ResourceId (2), whereLabel a StringRef (5) and whereLegacyUuid a plain
+    string (11).
+    """
+    payload = b""
+    if annotation_rid is not None:
+        payload += _field_bytes(2, _field_string(1, annotation_rid))
+    if fixture_type is not None:
+        payload += _field_bytes(4, _field_varint(1, fixture_type))
+    if label is not None:
+        payload += _field_bytes(5, _field_string(1, label))
+    if legacy_uuid is not None:
+        payload += _field_string(11, legacy_uuid)
+    return payload

--- a/tests/pynest/test_protobuf.py
+++ b/tests/pynest/test_protobuf.py
@@ -9,6 +9,7 @@ from custom_components.nest_protect.pynest.protobuf import (
     LIVENESS_TYPE_URL,
     NEST_KRYPTONITE_RESOURCE,
     PEER_DEVICES_TYPE_URL,
+    RCS_SETTINGS_TYPE_URL,
     STRUCTURE_INFO_TYPE_URL,
     STRUCTURE_MODE_CHANGE_TYPE_URL,
     STRUCTURE_MODE_TYPE_URL,
@@ -25,6 +26,8 @@ from custom_components.nest_protect.pynest.protobuf import (
     encode_structure_mode_change_request,
     encode_structure_mode_resource_command_request,
 )
+
+THERMOSTAT_RESOURCE = "nest.resource.NestLearningThermostat3Resource"
 
 
 def test_encode_structure_mode_change_request_home():
@@ -64,6 +67,7 @@ def test_encode_observe_request_asks_for_home_away_traits():
     assert b"nest.trait.occupancy.StructureModeTrait" in result
     assert b"weave.trait.peerdevices.PeerDevicesTrait" in result
     assert b"nest.trait.sensor.TemperatureTrait" in result
+    assert b"nest.trait.hvac.RemoteComfortSensingSettingsTrait" in result
 
 
 def test_decode_observe_stream_frames():
@@ -211,12 +215,207 @@ def test_decode_kryptonite_peer_devices_and_traits():
     assert device_updates[5].value == {"battery_status": 1, "battery_level": 87.5}
 
 
+def test_decode_thermostat_peer_device_and_temperatures():
+    """Test a thermostat mounts as device.<id> with both temperature traits."""
+    state = ProtobufObserveState(user_id="USER_123")
+    payload = _stream_body(
+        _get_property(
+            "STRUCTURE_new",
+            STRUCTURE_INFO_TYPE_URL,
+            _field_string(1, "structure.legacy"),
+        ),
+        _get_property(
+            "STRUCTURE_new",
+            PEER_DEVICES_TYPE_URL,
+            _field_bytes(
+                1,
+                _field_bytes(
+                    2,
+                    _field_bytes(1, _field_string(1, "DEVICE_09AB12"))
+                    + _field_bytes(2, _field_string(1, THERMOSTAT_RESOURCE))
+                    + _field_string(5, "6.2.1"),
+                ),
+            ),
+        ),
+        _get_property(
+            "09AB12",
+            TEMPERATURE_TYPE_URL,
+            _field_bytes(1, _field_bytes(1, _field_float(1, 21.5))),
+            trait_label="backplate_temperature",
+        ),
+        _get_property(
+            "09AB12",
+            TEMPERATURE_TYPE_URL,
+            _field_bytes(1, _field_bytes(1, _field_float(1, 19.0))),
+            trait_label="current_temperature",
+        ),
+        _get_property(
+            "09AB12",
+            DEVICE_IDENTITY_TYPE_URL,
+            _field_bytes(4, _field_string(1, "Nest Learning Thermostat"))
+            + _field_string(6, "thermostat-serial")
+            + _field_string(7, "6.2.2"),
+        ),
+    )
+
+    updates = decode_structure_updates(payload, state)
+    device_updates = [
+        update for update in updates if isinstance(update, ProtobufDeviceUpdate)
+    ]
+
+    assert device_updates[0].object_key == "device.09AB12"
+    assert device_updates[0].value == {
+        "using_protobuf": True,
+        "device_id": "09AB12",
+        "structure_id": "legacy",
+        "current_version": "6.2.1",
+        "user_id": "USER_123",
+        "protobuf_device_type": THERMOSTAT_RESOURCE,
+    }
+    # Both traits are nest.trait.sensor.TemperatureTrait; only the label differs.
+    assert device_updates[1].object_key == "device.09AB12"
+    assert device_updates[1].value == {"backplate_temperature": 21.5}
+    assert device_updates[2].value == {"current_temperature": 19.0}
+    assert device_updates[3].value == {
+        "model": "Nest Learning Thermostat",
+        "serial_number": "thermostat-serial",
+        "current_version": "6.2.2",
+    }
+
+
+def test_decode_rcs_settings_single_sensor():
+    """Test the selected remote comfort sensor is decoded."""
+    state = ProtobufObserveState(device_types={"09AB12": THERMOSTAT_RESOURCE})
+    payload = _stream_body(
+        _get_property(
+            "09AB12",
+            RCS_SETTINGS_TYPE_URL,
+            _field_varint(1, 3)  # rcsControlMode: SCHEDULE_OVERRIDE
+            + _field_bytes(
+                2,
+                _field_varint(1, 2)  # rcsSourceType: SINGLE_SENSOR
+                + _field_bytes(2, _field_string(1, "DEVICE_18B430")),
+            )
+            + _field_bytes(4, _field_bytes(1, _field_string(1, "DEVICE_18B430")))
+            + _field_bytes(4, _field_bytes(1, _field_string(1, "DEVICE_29CD34"))),
+            trait_label="remote_comfort_sensing_settings",
+        )
+    )
+
+    updates = decode_structure_updates(payload, state)
+
+    assert updates[0].value == {
+        "rcs_control_mode": 3,
+        "rcs_source_type": 2,
+        "active_rcs_sensors": ["kryptonite.18B430"],
+        "associated_rcs_sensors": ["kryptonite.18B430", "kryptonite.29CD34"],
+    }
+
+
+def test_decode_rcs_settings_backplate_clears_selection():
+    """Test falling back to the thermostat's own sensor empties the selection."""
+    state = ProtobufObserveState(device_types={"09AB12": THERMOSTAT_RESOURCE})
+    payload = _stream_body(
+        _get_property(
+            "09AB12",
+            RCS_SETTINGS_TYPE_URL,
+            # rcsSourceType BACKPLATE, with activeRcsSensor cleared.
+            _field_bytes(2, _field_varint(1, 1))
+            + _field_bytes(4, _field_bytes(1, _field_string(1, "DEVICE_18B430"))),
+            trait_label="remote_comfort_sensing_settings",
+        )
+    )
+
+    updates = decode_structure_updates(payload, state)
+
+    assert updates[0].value == {
+        "rcs_control_mode": None,
+        "rcs_source_type": 1,
+        "active_rcs_sensors": [],
+        "associated_rcs_sensors": ["kryptonite.18B430"],
+    }
+
+
+def test_decode_rcs_settings_multi_sensor():
+    """Test a multi-sensor average reports the whole group as active."""
+    state = ProtobufObserveState(device_types={"09AB12": THERMOSTAT_RESOURCE})
+    payload = _stream_body(
+        _get_property(
+            "09AB12",
+            RCS_SETTINGS_TYPE_URL,
+            _field_bytes(2, _field_varint(1, 3))  # rcsSourceType: MULTI_SENSOR
+            + _field_bytes(
+                5,
+                _field_varint(1, 1)  # multiSensorEnabled
+                + _field_bytes(2, _field_string(1, "DEVICE_18B430"))
+                + _field_bytes(2, _field_string(1, "DEVICE_29CD34")),
+            ),
+            trait_label="remote_comfort_sensing_settings",
+        )
+    )
+
+    updates = decode_structure_updates(payload, state)
+
+    assert updates[0].value["active_rcs_sensors"] == [
+        "kryptonite.18B430",
+        "kryptonite.29CD34",
+    ]
+
+
+def test_decode_skips_bucketized_trait_labels():
+    """Test bucketized temperature history is ignored."""
+    state = ProtobufObserveState(device_types={"09AB12": THERMOSTAT_RESOURCE})
+    payload = _stream_body(
+        _get_property(
+            "09AB12",
+            TEMPERATURE_TYPE_URL,
+            _field_bytes(1, _field_bytes(1, _field_float(1, 21.5))),
+            trait_label="backplate_temperature_bucketized",
+        )
+    )
+
+    assert decode_structure_updates(payload, state) == []
+
+
+def test_decode_ignores_unsupported_peer_device_types():
+    """Test peer devices we have no bucket mapping for are skipped."""
+    state = ProtobufObserveState(
+        user_id="USER_123",
+        legacy_structure_ids={"STRUCTURE_new": "legacy"},
+    )
+    payload = _stream_body(
+        _get_property(
+            "STRUCTURE_new",
+            PEER_DEVICES_TYPE_URL,
+            _field_bytes(
+                1,
+                _field_bytes(
+                    2,
+                    _field_bytes(1, _field_string(1, "DEVICE_CAM01"))
+                    + _field_bytes(
+                        2, _field_string(1, "nest.resource.NestCamIndoorResource")
+                    ),
+                ),
+            ),
+        )
+    )
+
+    assert decode_structure_updates(payload, state) == []
+
+
 def _stream_body(*get_properties: bytes) -> bytes:
     return _field_bytes(1, b"".join(_field_bytes(3, get) for get in get_properties))
 
 
-def _get_property(resource_id: str, type_url: str, value: bytes) -> bytes:
+def _get_property(
+    resource_id: str,
+    type_url: str,
+    value: bytes,
+    trait_label: str | None = None,
+) -> bytes:
     object_id = _field_string(1, resource_id)
+    if trait_label is not None:
+        object_id += _field_string(2, trait_label)
     any_payload = _field_string(1, type_url) + _field_bytes(2, value)
     indirect = _field_bytes(1, any_payload)
     return _field_bytes(1, object_id) + _field_bytes(3, indirect)

--- a/tests/pynest/test_protobuf.py
+++ b/tests/pynest/test_protobuf.py
@@ -6,6 +6,7 @@ from custom_components.nest_protect.pynest.protobuf import (
     BATTERY_TYPE_URL,
     DEVICE_IDENTITY_TYPE_URL,
     DEVICE_LOCATED_SETTINGS_TYPE_URL,
+    HUMIDITY_TYPE_URL,
     LIVENESS_TYPE_URL,
     NEST_KRYPTONITE_RESOURCE,
     PEER_DEVICES_TYPE_URL,
@@ -67,6 +68,7 @@ def test_encode_observe_request_asks_for_home_away_traits():
     assert b"nest.trait.occupancy.StructureModeTrait" in result
     assert b"weave.trait.peerdevices.PeerDevicesTrait" in result
     assert b"nest.trait.sensor.TemperatureTrait" in result
+    assert b"nest.trait.sensor.HumidityTrait" in result
     assert b"nest.trait.hvac.RemoteComfortSensingSettingsTrait" in result
 
 
@@ -281,6 +283,24 @@ def test_decode_thermostat_peer_device_and_temperatures():
         "serial_number": "thermostat-serial",
         "current_version": "6.2.2",
     }
+
+
+def test_decode_thermostat_humidity():
+    """Test HumidityTrait decodes with the same nesting as temperature."""
+    state = ProtobufObserveState(device_types={"09AB12": THERMOSTAT_RESOURCE})
+    payload = _stream_body(
+        _get_property(
+            "09AB12",
+            HUMIDITY_TYPE_URL,
+            _field_bytes(1, _field_bytes(1, _field_float(1, 43.5))),
+            trait_label="current_humidity",
+        )
+    )
+
+    updates = decode_structure_updates(payload, state)
+
+    assert updates[0].object_key == "device.09AB12"
+    assert updates[0].value == {"current_humidity": 43.5}
 
 
 def test_decode_rcs_settings_single_sensor():

--- a/tests/pynest/test_protobuf.py
+++ b/tests/pynest/test_protobuf.py
@@ -8,6 +8,7 @@ from custom_components.nest_protect.pynest.protobuf import (
     DEVICE_LOCATED_SETTINGS_TYPE_URL,
     HUMIDITY_TYPE_URL,
     LIVENESS_TYPE_URL,
+    MAX_PENDING_DEVICES,
     NEST_KRYPTONITE_RESOURCE,
     PEER_DEVICES_TYPE_URL,
     RCS_SETTINGS_TYPE_URL,
@@ -526,6 +527,273 @@ def test_decode_ignores_unsupported_peer_device_types():
     )
 
     assert decode_structure_updates(payload, state) == []
+
+
+def test_decode_replays_device_traits_that_arrive_before_peer_devices():
+    """Test a reading published before the device is mapped is not lost.
+
+    PeerDevicesTrait is the only thing that maps a device id to a type, and the
+    gateway gives no ordering guarantee against the per-device traits. Dropping
+    the early ones left the entity unknown until the device happened to
+    republish — tens of minutes for temperature, hours for RCS settings.
+    """
+    state = ProtobufObserveState(user_id="USER_123")
+    payload = _stream_body(
+        _get_property(
+            "DEVICE_09AB12",
+            TEMPERATURE_TYPE_URL,
+            _field_bytes(1, _field_bytes(1, _field_float(1, 21.5))),
+            trait_label="current_temperature",
+        ),
+        _get_property(
+            "STRUCTURE_new",
+            STRUCTURE_INFO_TYPE_URL,
+            _field_string(1, "structure.legacy"),
+        ),
+        _get_property(
+            "STRUCTURE_new",
+            PEER_DEVICES_TYPE_URL,
+            _peer_devices(("DEVICE_09AB12", THERMOSTAT_RESOURCE)),
+        ),
+    )
+
+    updates = decode_structure_updates(payload, state)
+    device_updates = [
+        update for update in updates if isinstance(update, ProtobufDeviceUpdate)
+    ]
+
+    assert device_updates[0].value["protobuf_device_type"] == THERMOSTAT_RESOURCE
+    assert device_updates[1].object_key == "device.09AB12"
+    assert device_updates[1].value == {"current_temperature": 21.5}
+    assert state.pending_device_traits == {}
+
+
+def test_decode_replays_device_traits_held_across_frames():
+    """Test a trait parked in one frame is released by a later frame."""
+    state = ProtobufObserveState(user_id="USER_123")
+
+    early = decode_structure_updates(
+        _stream_body(
+            _get_property(
+                "DEVICE_18B430",
+                TEMPERATURE_TYPE_URL,
+                _field_bytes(1, _field_bytes(1, _field_float(1, 19.0))),
+            )
+        ),
+        state,
+    )
+    assert early == []
+    assert "18B430" in state.pending_device_traits
+
+    updates = decode_structure_updates(
+        _stream_body(
+            _get_property(
+                "STRUCTURE_new",
+                STRUCTURE_INFO_TYPE_URL,
+                _field_string(1, "structure.legacy"),
+            ),
+            _get_property(
+                "STRUCTURE_new",
+                PEER_DEVICES_TYPE_URL,
+                _peer_devices(("DEVICE_18B430", NEST_KRYPTONITE_RESOURCE)),
+            ),
+        ),
+        state,
+    )
+
+    assert updates[-1].object_key == "kryptonite.18B430"
+    assert updates[-1].value == {"current_temperature": 19.0}
+
+
+def test_decode_replays_peer_devices_that_arrive_before_structure_info():
+    """Test peer devices held until the structure has a legacy id.
+
+    Dropping the list here left every device on that structure unmapped for the
+    life of the stream, which is the all-sensors-unknown case after a restart.
+    """
+    state = ProtobufObserveState(user_id="USER_123")
+    payload = _stream_body(
+        _get_property(
+            "DEVICE_09AB12",
+            TEMPERATURE_TYPE_URL,
+            _field_bytes(1, _field_bytes(1, _field_float(1, 21.5))),
+            trait_label="current_temperature",
+        ),
+        _get_property(
+            "STRUCTURE_new",
+            PEER_DEVICES_TYPE_URL,
+            _peer_devices(("DEVICE_09AB12", THERMOSTAT_RESOURCE)),
+        ),
+        _get_property(
+            "STRUCTURE_new",
+            STRUCTURE_INFO_TYPE_URL,
+            _field_string(1, "structure.legacy"),
+        ),
+    )
+
+    updates = decode_structure_updates(payload, state)
+    device_updates = [
+        update for update in updates if isinstance(update, ProtobufDeviceUpdate)
+    ]
+
+    assert device_updates[0].value["structure_id"] == "legacy"
+    assert device_updates[1].value == {"current_temperature": 21.5}
+    assert state.pending_peer_devices == {}
+    assert state.pending_device_traits == {}
+
+
+def test_decode_drops_traits_for_devices_known_to_be_unsupported():
+    """Test an unsupported device's traits are dropped, not held.
+
+    A Protect or Guard on the protobuf stream publishes constantly; parking
+    every one of those would keep the buffer churning for the life of the run.
+    """
+    state = ProtobufObserveState(
+        user_id="USER_123",
+        legacy_structure_ids={"STRUCTURE_new": "legacy"},
+    )
+    decode_structure_updates(
+        _stream_body(
+            _get_property(
+                "STRUCTURE_new",
+                PEER_DEVICES_TYPE_URL,
+                _peer_devices(("DEVICE_CAM01", "nest.resource.NestCamIndoorResource")),
+            )
+        ),
+        state,
+    )
+    assert state.unsupported_devices == {"CAM01"}
+
+    updates = decode_structure_updates(
+        _stream_body(
+            _get_property(
+                "DEVICE_CAM01",
+                TEMPERATURE_TYPE_URL,
+                _field_bytes(1, _field_bytes(1, _field_float(1, 21.5))),
+            )
+        ),
+        state,
+    )
+
+    assert updates == []
+    assert state.pending_device_traits == {}
+
+
+def test_pending_device_traits_supersede_rather_than_accumulate():
+    """Test repeated publishes by an unmapped device don't grow the buffer.
+
+    The stream is meant to stay up for weeks; a device that never gets mapped
+    must not be able to grow memory one sample at a time.
+    """
+    state = ProtobufObserveState()
+
+    for sample in (19.0, 20.0, 21.0):
+        decode_structure_updates(
+            _stream_body(
+                _get_property(
+                    "DEVICE_18B430",
+                    TEMPERATURE_TYPE_URL,
+                    _field_bytes(1, _field_bytes(1, _field_float(1, sample))),
+                    trait_label="current_temperature",
+                )
+            ),
+            state,
+        )
+
+    assert len(state.pending_device_traits["18B430"]) == 1
+
+    state.legacy_structure_ids["STRUCTURE_new"] = "legacy"
+    updates = decode_structure_updates(
+        _stream_body(
+            _get_property(
+                "STRUCTURE_new",
+                PEER_DEVICES_TYPE_URL,
+                _peer_devices(("DEVICE_18B430", NEST_KRYPTONITE_RESOURCE)),
+            )
+        ),
+        state,
+    )
+
+    # Only the newest sample survives, and it is the one replayed.
+    assert updates[-1].value == {"current_temperature": 21.0}
+
+
+def test_pending_device_traits_are_capped():
+    """Test the parked-trait buffer is bounded, oldest evicted first."""
+    state = ProtobufObserveState()
+
+    for index in range(MAX_PENDING_DEVICES + 5):
+        decode_structure_updates(
+            _stream_body(
+                _get_property(
+                    f"DEVICE_{index:06X}",
+                    TEMPERATURE_TYPE_URL,
+                    _field_bytes(1, _field_bytes(1, _field_float(1, 19.0))),
+                )
+            ),
+            state,
+        )
+
+    assert len(state.pending_device_traits) == MAX_PENDING_DEVICES
+    assert f"{0:06X}" not in state.pending_device_traits
+    assert f"{MAX_PENDING_DEVICES + 4:06X}" in state.pending_device_traits
+
+
+def test_decode_reemits_structures_when_the_user_arrives_late():
+    """Test a late UserInfoTrait backfills the user id on known structures.
+
+    Home/Away cannot build a command without it, and structure traits are not
+    republished on any useful schedule.
+    """
+    state = ProtobufObserveState()
+    decode_structure_updates(
+        _stream_body(
+            _get_property(
+                "STRUCTURE_new",
+                STRUCTURE_INFO_TYPE_URL,
+                _field_string(1, "structure.legacy"),
+            )
+        ),
+        state,
+    )
+
+    updates = decode_structure_updates(
+        _stream_body(
+            _get_property("USER_123", USER_INFO_TYPE_URL, _field_string(1, "user.leg"))
+        ),
+        state,
+    )
+
+    assert len(updates) == 1
+    assert updates[0].resource_id == "STRUCTURE_new"
+    assert updates[0].legacy_structure_id == "legacy"
+    assert updates[0].user_id == "USER_123"
+
+    # The same user id arriving again is not worth re-emitting for.
+    assert (
+        decode_structure_updates(
+            _stream_body(
+                _get_property(
+                    "USER_123", USER_INFO_TYPE_URL, _field_string(1, "user.leg")
+                )
+            ),
+            state,
+        )
+        == []
+    )
+
+
+def _peer_devices(*devices: tuple[str, str], firmware: str | None = None) -> bytes:
+    """Build a PeerDevicesTrait payload listing `(resource_id, device_type)`."""
+    entries = b""
+    for resource_id, device_type in devices:
+        data = _field_bytes(1, _field_string(1, resource_id)) + _field_bytes(
+            2, _field_string(1, device_type)
+        )
+        if firmware is not None:
+            data += _field_string(5, firmware)
+        entries += _field_bytes(1, _field_bytes(2, data))
+    return entries
 
 
 def _stream_body(*get_properties: bytes) -> bytes:

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -120,6 +120,31 @@ def test_kryptonite_device_info():
     assert device_info["model"] == "Kryp-1.0"
 
 
+def test_area_falls_back_to_the_protobuf_where_label():
+    """Test the room name published by DeviceLocatedSettingsTrait is used.
+
+    Thermostats have no `where.` REST bucket, so a room that never appears in
+    `areas` can still be named from the trait's own literal.
+    """
+    entity = build_entity(
+        {"where_id": "where.unmapped", "where_label": "Guest room"},
+        object_key="device.09AB12",
+    )
+
+    assert entity.area == "Guest room"
+    assert entity.device_info["name"] == "Nest Thermostat (Guest room)"
+
+
+def test_area_prefers_the_mapped_where_id_over_the_label():
+    """Test the user-facing `where.` bucket name wins when it resolves."""
+    entity = build_entity(
+        {"where_id": "where.living-room", "where_label": "Stale label"},
+        object_key="device.09AB12",
+    )
+
+    assert entity.area == "Living Room"
+
+
 def test_incomplete_kryptonite_falls_back_to_object_key():
     """Test that a temperature sensor without a serial number still sets up."""
     device_info = build_entity({}, object_key="kryptonite.5678").device_info

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -126,3 +126,30 @@ def test_incomplete_kryptonite_falls_back_to_object_key():
 
     assert device_info["identifiers"] == {(DOMAIN, "kryptonite.5678")}
     assert device_info["name"] == "Nest Temperature Sensor"
+
+
+def test_thermostat_device_info():
+    """Test that a protobuf-discovered thermostat reports its own device info."""
+    device_info = build_entity(
+        {
+            "where_id": "where.living-room",
+            "serial_number": "THERM123",
+            "model": "Nest Learning Thermostat",
+            "current_version": "6.2.2",
+        },
+        object_key="device.09AB12",
+    ).device_info
+
+    assert device_info["identifiers"] == {(DOMAIN, "THERM123")}
+    assert device_info["name"] == "Nest Thermostat (Living Room)"
+    assert device_info["model"] == "Nest Learning Thermostat"
+    assert device_info["sw_version"] == "6.2.2"
+
+
+def test_incomplete_thermostat_falls_back_to_object_key():
+    """Test that a thermostat without identity traits still sets up."""
+    device_info = build_entity({}, object_key="device.09AB12").device_info
+
+    assert device_info["identifiers"] == {(DOMAIN, "device.09AB12")}
+    assert device_info["name"] == "Nest Thermostat"
+    assert device_info["model"] is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -317,7 +317,7 @@ def _make_subscriber_entry_data(
     sm._consecutive_failures = consecutive_failures
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = HomeAssistantNestProtectData(
-        devices={}, areas={}, client=client, session_manager=sm
+        devices={}, structures={}, areas={}, client=client, session_manager=sm
     )
     return client, sm
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,12 +12,27 @@ from custom_components.nest_protect import (
     DOMAIN,
     HomeAssistantNestProtectData,
     _async_subscribe_for_data,
+    _next_observe_delay,
+    _seed_protobuf_observe_state,
 )
-from custom_components.nest_protect.const import CONF_COOKIES, MAX_AUTH_FAILURES
+from custom_components.nest_protect.const import (
+    CONF_COOKIES,
+    MAX_AUTH_FAILURES,
+    PROTOBUF_RECONNECT_INITIAL_DELAY,
+    PROTOBUF_RECONNECT_MAX_DELAY,
+    PROTOBUF_STREAM_HEALTHY_SECONDS,
+)
 from custom_components.nest_protect.pynest.exceptions import NotAuthenticatedException
+from custom_components.nest_protect.pynest.models import Bucket
+from custom_components.nest_protect.pynest.protobuf import (
+    NEST_KRYPTONITE_RESOURCE,
+    ProtobufObserveState,
+)
 from custom_components.nest_protect.session import NestSessionManager
 
 from .conftest import COOKIES, ISSUE_TOKEN, ComponentSetup
+
+THERMOSTAT_RESOURCE = "nest.resource.NestLearningThermostat3Resource"
 
 
 @pytest.mark.skip(
@@ -491,3 +506,74 @@ async def test_subscriber_success_resets_failure_counter(hass):
         await _async_subscribe_for_data(hass, entry, _make_subscribe_data())
 
     assert sm.consecutive_failures == 0
+
+
+def _make_seed_entry_data(devices):
+    """Build entry data whose client carries a real observe state."""
+    client = MagicMock()
+    client.protobuf_observe_state = ProtobufObserveState()
+
+    return HomeAssistantNestProtectData(
+        devices=devices,
+        structures={},
+        areas={},
+        client=client,
+        session_manager=MagicMock(),
+        grpc_lock_client=MagicMock(),
+    )
+
+
+def _bucket(object_key, value):
+    return Bucket(
+        object_key=object_key, object_revision=0, object_timestamp=0, value=value
+    )
+
+
+def test_seed_observe_state_from_known_devices():
+    """Devices known at setup are pushed into the observe decoder.
+
+    Without this the first stream after a restart has to see PeerDevicesTrait
+    before it will accept any reading, and every trait that arrives first is
+    held until the device republishes.
+    """
+    entry_data = _make_seed_entry_data(
+        {
+            "device.09AB12": _bucket(
+                "device.09AB12",
+                {
+                    "device_id": "09AB12",
+                    "protobuf_device_type": THERMOSTAT_RESOURCE,
+                    "serial_number": "thermostat-serial",
+                },
+            ),
+            "kryptonite.18B430": _bucket(
+                "kryptonite.18B430", {"current_temperature": 19.0}
+            ),
+            "topaz.AABBCC": _bucket("topaz.AABBCC", {"battery_level": 5000}),
+        }
+    )
+
+    _seed_protobuf_observe_state(entry_data)
+    state = entry_data.client.protobuf_observe_state
+
+    assert state.device_types == {
+        "09AB12": THERMOSTAT_RESOURCE,
+        "18B430": NEST_KRYPTONITE_RESOURCE,
+    }
+    # Protects are served over REST, so their protobuf traits are dropped
+    # rather than held for a mapping that never arrives.
+    assert state.unsupported_devices == {"AABBCC"}
+
+
+def test_observe_reconnect_delay_backs_off_then_resets():
+    """Short-lived streams back off; a healthy one returns to the floor."""
+    delay = PROTOBUF_RECONNECT_INITIAL_DELAY
+
+    for _ in range(20):
+        delay = _next_observe_delay(delay, stream_duration=0.5)
+    assert delay == PROTOBUF_RECONNECT_MAX_DELAY
+
+    assert (
+        _next_observe_delay(delay, stream_duration=PROTOBUF_STREAM_HEALTHY_SECONDS)
+        == PROTOBUF_RECONNECT_INITIAL_DELAY
+    )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -318,6 +318,7 @@ def _make_subscriber_entry_data(
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = HomeAssistantNestProtectData(
         devices={},
+        structures={},
         areas={},
         client=client,
         session_manager=sm,

--- a/tests/test_thermostat.py
+++ b/tests/test_thermostat.py
@@ -1,0 +1,362 @@
+"""Tests for thermostat discovery from the protobuf observe stream."""
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.nest_protect import (
+    DOMAIN,
+    HomeAssistantNestProtectData,
+    _apply_protobuf_device_update,
+)
+from custom_components.nest_protect.pynest.models import Bucket
+from custom_components.nest_protect.pynest.protobuf import ProtobufDeviceUpdate
+from custom_components.nest_protect.pynest.protobuf import (
+    RCS_SOURCE_TYPE_BACKPLATE,
+    RCS_SOURCE_TYPE_MULTI_SENSOR,
+    RCS_SOURCE_TYPE_SINGLE_SENSOR,
+)
+from custom_components.nest_protect.sensor import (
+    ACTIVE_TEMPERATURE_SENSOR_DESCRIPTION,
+    SENSOR_DESCRIPTIONS,
+    THERMOSTAT_SENSOR_KEYS,
+    NestThermostatActiveSensor,
+    NestThermostatSensor,
+)
+from custom_components.nest_protect.thermostat import (
+    is_discoverable_thermostat,
+    subscribe_to_thermostat_discovery,
+    thermostat_discovery_signal,
+)
+
+THERMOSTAT_KEY = "device.09AB12"
+PEER_DEVICE_VALUE = {
+    "using_protobuf": True,
+    "device_id": "09AB12",
+    "structure_id": "legacy",
+    "protobuf_device_type": "nest.resource.NestLearningThermostat3Resource",
+}
+
+
+def _entry_data(**kwargs) -> HomeAssistantNestProtectData:
+    """Build a minimal HomeAssistantNestProtectData."""
+    return HomeAssistantNestProtectData(
+        devices=kwargs.pop("devices", {}),
+        structures={},
+        areas=kwargs.pop("areas", {}),
+        client=MagicMock(),
+        session_manager=MagicMock(),
+        grpc_lock_client=MagicMock(),
+        **kwargs,
+    )
+
+
+def _thermostat_bucket(value: dict | None = None) -> Bucket:
+    """Build a thermostat bucket as protobuf discovery would."""
+    return Bucket(
+        object_key=THERMOSTAT_KEY,
+        object_revision=0,
+        object_timestamp=0,
+        value={**PEER_DEVICE_VALUE, **(value or {})},
+    )
+
+
+async def test_thermostat_update_creates_bucket_and_defers_discovery(hass):
+    """Test the bucket is created but discovery waits for the serial number."""
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry_data = _entry_data()
+    discovered: list[Bucket] = []
+    async_dispatcher_connect(
+        hass, thermostat_discovery_signal(entry.entry_id), discovered.append
+    )
+
+    _apply_protobuf_device_update(
+        hass,
+        entry,
+        entry_data,
+        ProtobufDeviceUpdate(object_key=THERMOSTAT_KEY, value=PEER_DEVICE_VALUE),
+    )
+    await hass.async_block_till_done()
+
+    assert entry_data.devices[THERMOSTAT_KEY].value == PEER_DEVICE_VALUE
+    assert entry_data.devices[THERMOSTAT_KEY].type == "device"
+    assert not discovered
+
+
+async def test_thermostat_discovery_fires_once_identity_arrives(hass):
+    """Test discovery fires on the identity trait, then updates go per-object."""
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry_data = _entry_data()
+    discovered: list[Bucket] = []
+    updated: list[Bucket] = []
+    async_dispatcher_connect(
+        hass, thermostat_discovery_signal(entry.entry_id), discovered.append
+    )
+    async_dispatcher_connect(hass, THERMOSTAT_KEY, updated.append)
+
+    for value in (
+        PEER_DEVICE_VALUE,
+        {"serial_number": "thermostat-serial", "model": "Nest Learning Thermostat"},
+        {"backplate_temperature": 21.5},
+    ):
+        _apply_protobuf_device_update(
+            hass,
+            entry,
+            entry_data,
+            ProtobufDeviceUpdate(object_key=THERMOSTAT_KEY, value=value),
+        )
+    await hass.async_block_till_done()
+
+    assert len(discovered) == 1
+    assert discovered[0].value["serial_number"] == "thermostat-serial"
+    # The bucket is mutated in place, so the announced bucket carries the
+    # temperature that arrived after discovery.
+    assert len(updated) == 1
+    assert updated[0] is discovered[0]
+    assert discovered[0].value["backplate_temperature"] == 21.5
+
+
+async def test_unknown_non_thermostat_update_is_dropped(hass):
+    """Test devices other than thermostats still need a legacy bucket first."""
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry_data = _entry_data()
+
+    _apply_protobuf_device_update(
+        hass,
+        entry,
+        entry_data,
+        ProtobufDeviceUpdate(
+            object_key="kryptonite.18B430", value={"current_temperature": 21.5}
+        ),
+    )
+    await hass.async_block_till_done()
+
+    assert entry_data.devices == {}
+
+
+async def test_subscribe_replays_already_discovered_thermostats(hass):
+    """Test thermostats found before platform setup are replayed exactly once."""
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+    bucket = _thermostat_bucket({"serial_number": "thermostat-serial"})
+    topaz = Bucket(
+        object_key="topaz.1234", object_revision=0, object_timestamp=0, value={}
+    )
+    entry_data = _entry_data(devices={THERMOSTAT_KEY: bucket, "topaz.1234": topaz})
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry_data
+    added: list[Bucket] = []
+
+    subscribe_to_thermostat_discovery(
+        hass,
+        entry,
+        lambda entities: None,
+        lambda discovered: added.append(discovered) or [MagicMock()],
+    )
+
+    assert added == [bucket]
+
+    # A late discovery signal for the same thermostat must not add it twice.
+    async_dispatcher_send(hass, thermostat_discovery_signal(entry.entry_id), bucket)
+    await hass.async_block_till_done()
+
+    assert added == [bucket]
+
+
+async def test_discovery_creates_both_temperature_sensors(hass):
+    """Test the sensor platform adds both temperatures for one thermostat."""
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+    bucket = _thermostat_bucket(
+        {
+            "serial_number": "thermostat-serial",
+            "where_id": "where.living-room",
+            "backplate_temperature": 21.51234,
+        }
+    )
+    entry_data = _entry_data(
+        devices={THERMOSTAT_KEY: bucket}, areas={"where.living-room": "Living Room"}
+    )
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry_data
+    added: list[NestThermostatSensor] = []
+
+    descriptions = [
+        description
+        for description in SENSOR_DESCRIPTIONS
+        if description.key in THERMOSTAT_SENSOR_KEYS
+    ]
+    subscribe_to_thermostat_discovery(
+        hass,
+        entry,
+        added.extend,
+        lambda discovered: [
+            NestThermostatSensor(discovered, description, entry_data.areas, MagicMock())
+            for description in descriptions
+        ],
+    )
+
+    by_key = {sensor.entity_description.key: sensor for sensor in added}
+    assert set(by_key) == {"backplate_temperature", "current_temperature"}
+    assert by_key["backplate_temperature"].unique_id == (
+        "device.09AB12-backplate_temperature"
+    )
+    assert by_key["backplate_temperature"].native_value == 21.51
+    # Not published yet — the entity is added up front and fills in later.
+    assert by_key["current_temperature"].native_value is None
+    assert by_key["current_temperature"].device_info["name"] == (
+        "Nest Thermostat (Living Room)"
+    )
+
+
+def _active_sensor_entity(rcs: dict) -> NestThermostatActiveSensor:
+    """Build the active-source sensor with one named temperature sensor known."""
+    kryptonite = Bucket(
+        object_key="kryptonite.18B430",
+        object_revision=0,
+        object_timestamp=0,
+        value={"where_id": "where.hallway"},
+    )
+    bucket = _thermostat_bucket({"serial_number": "thermostat-serial", **rcs})
+
+    return NestThermostatActiveSensor(
+        bucket,
+        ACTIVE_TEMPERATURE_SENSOR_DESCRIPTION,
+        {"where.hallway": "Hallway"},
+        MagicMock(),
+        {THERMOSTAT_KEY: bucket, "kryptonite.18B430": kryptonite},
+    )
+
+
+def test_active_sensor_names_the_selected_remote_sensor():
+    """Test a single selected sensor is reported by its room name."""
+    sensor = _active_sensor_entity(
+        {
+            "rcs_source_type": RCS_SOURCE_TYPE_SINGLE_SENSOR,
+            "active_rcs_sensors": ["kryptonite.18B430"],
+            "associated_rcs_sensors": ["kryptonite.18B430", "kryptonite.29CD34"],
+        }
+    )
+
+    assert sensor.native_value == "Hallway"
+    assert sensor.extra_state_attributes == {
+        "source_type": "single_sensor",
+        "active_sensors": ["kryptonite.18B430"],
+        "associated_sensors": ["kryptonite.18B430", "kryptonite.29CD34"],
+    }
+
+
+def test_active_sensor_reports_the_thermostat_itself():
+    """Test the backplate source reads as the thermostat, not a sensor."""
+    sensor = _active_sensor_entity(
+        {
+            "rcs_source_type": RCS_SOURCE_TYPE_BACKPLATE,
+            "active_rcs_sensors": [],
+            "associated_rcs_sensors": ["kryptonite.18B430"],
+        }
+    )
+
+    assert sensor.native_value == "Thermostat"
+    assert sensor.extra_state_attributes["source_type"] == "backplate"
+
+
+def test_active_sensor_falls_back_to_the_device_id():
+    """Test a selected sensor we have no bucket for still identifies itself."""
+    sensor = _active_sensor_entity(
+        {
+            "rcs_source_type": RCS_SOURCE_TYPE_SINGLE_SENSOR,
+            "active_rcs_sensors": ["kryptonite.29CD34"],
+        }
+    )
+
+    assert sensor.native_value == "29CD34"
+
+
+def test_active_sensor_lists_a_multi_sensor_group():
+    """Test an averaged group names every sensor in it."""
+    sensor = _active_sensor_entity(
+        {
+            "rcs_source_type": RCS_SOURCE_TYPE_MULTI_SENSOR,
+            "active_rcs_sensors": ["kryptonite.29CD34", "kryptonite.18B430"],
+        }
+    )
+
+    assert sensor.native_value == "29CD34, Hallway"
+    assert sensor.extra_state_attributes["source_type"] == "multi_sensor"
+
+
+def test_active_sensor_is_unknown_before_the_trait_arrives():
+    """Test the entity is added up front and stays unknown until published."""
+    sensor = _active_sensor_entity({})
+
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes == {
+        "source_type": "unknown",
+        "active_sensors": [],
+        "associated_sensors": [],
+    }
+
+
+async def test_late_identity_traits_update_the_device_registry(hass):
+    """Test model/room traits arriving after the entity is added rename the device."""
+    bucket = _thermostat_bucket({"serial_number": "thermostat-serial"})
+    areas = {"where.living-room": "Living Room"}
+    description = next(
+        d for d in SENSOR_DESCRIPTIONS if d.key == "backplate_temperature"
+    )
+    sensor = NestThermostatSensor(bucket, description, areas, MagicMock())
+    sensor.hass = hass
+    sensor.async_write_ha_state = MagicMock()
+
+    assert sensor.device_info["name"] == "Nest Thermostat"
+
+    # The observe loop mutates the bucket in place before dispatching it, so the
+    # entity cannot recover the previous values from the bucket it receives.
+    bucket.value.update(
+        {
+            "model": "Nest Learning Thermostat",
+            "current_version": "6.2.2",
+            "where_id": "where.living-room",
+        }
+    )
+
+    device_entry = MagicMock(id="device-entry-id")
+    with (
+        patch.object(
+            type(sensor), "device_entry", PropertyMock(return_value=device_entry)
+        ),
+        patch("custom_components.nest_protect.sensor.dr.async_get") as async_get,
+    ):
+        sensor.update_callback(bucket)
+
+        async_get.return_value.async_update_device.assert_called_once_with(
+            "device-entry-id",
+            name="Nest Thermostat (Living Room)",
+            model="Nest Learning Thermostat",
+            sw_version="6.2.2",
+        )
+
+        # A temperature-only update must not touch the registry again.
+        async_get.return_value.async_update_device.reset_mock()
+        bucket.value["backplate_temperature"] = 21.5
+        sensor.update_callback(bucket)
+
+        async_get.return_value.async_update_device.assert_not_called()
+
+
+async def test_incomplete_thermostat_is_not_discoverable():
+    """Test a thermostat without a serial number is not ready to be added."""
+    assert not is_discoverable_thermostat(_thermostat_bucket())
+    assert is_discoverable_thermostat(
+        _thermostat_bucket({"serial_number": "thermostat-serial"})
+    )
+    assert not is_discoverable_thermostat(
+        Bucket(
+            object_key="kryptonite.18B430",
+            object_revision=0,
+            object_timestamp=0,
+            value={"serial_number": "sensor-serial"},
+        )
+    )

--- a/tests/test_thermostat.py
+++ b/tests/test_thermostat.py
@@ -1,6 +1,6 @@
 """Tests for thermostat discovery from the protobuf observe stream."""
 
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -12,13 +12,14 @@ from custom_components.nest_protect import (
     DOMAIN,
     HomeAssistantNestProtectData,
     _apply_protobuf_device_update,
+    _async_restore_protobuf_thermostats,
 )
 from custom_components.nest_protect.pynest.models import Bucket
-from custom_components.nest_protect.pynest.protobuf import ProtobufDeviceUpdate
 from custom_components.nest_protect.pynest.protobuf import (
     RCS_SOURCE_TYPE_BACKPLATE,
     RCS_SOURCE_TYPE_MULTI_SENSOR,
     RCS_SOURCE_TYPE_SINGLE_SENSOR,
+    ProtobufDeviceUpdate,
 )
 from custom_components.nest_protect.sensor import (
     ACTIVE_TEMPERATURE_SENSOR_DESCRIPTION,
@@ -166,8 +167,8 @@ async def test_subscribe_replays_already_discovered_thermostats(hass):
     assert added == [bucket]
 
 
-async def test_discovery_creates_both_temperature_sensors(hass):
-    """Test the sensor platform adds both temperatures for one thermostat."""
+async def test_discovery_creates_the_thermostat_sensors(hass):
+    """Test the sensor platform adds every thermostat reading in one go."""
     entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)
     bucket = _thermostat_bucket(
@@ -175,6 +176,7 @@ async def test_discovery_creates_both_temperature_sensors(hass):
             "serial_number": "thermostat-serial",
             "where_id": "where.living-room",
             "backplate_temperature": 21.51234,
+            "current_humidity": 43.6,
         }
     )
     entry_data = _entry_data(
@@ -199,11 +201,16 @@ async def test_discovery_creates_both_temperature_sensors(hass):
     )
 
     by_key = {sensor.entity_description.key: sensor for sensor in added}
-    assert set(by_key) == {"backplate_temperature", "current_temperature"}
+    assert set(by_key) == {
+        "backplate_temperature",
+        "current_temperature",
+        "current_humidity",
+    }
     assert by_key["backplate_temperature"].unique_id == (
         "device.09AB12-backplate_temperature"
     )
     assert by_key["backplate_temperature"].native_value == 21.51
+    assert by_key["current_humidity"].native_value == 44
     # Not published yet — the entity is added up front and fills in later.
     assert by_key["current_temperature"].native_value is None
     assert by_key["current_temperature"].device_info["name"] == (
@@ -297,6 +304,156 @@ def test_active_sensor_is_unknown_before_the_trait_arrives():
         "active_sensors": [],
         "associated_sensors": [],
     }
+
+
+async def test_active_sensor_name_resolves_when_the_sensor_traits_land(hass):
+    """Test a sensor's room label arriving later replaces the bare device id."""
+    kryptonite = Bucket(
+        object_key="kryptonite.18B430",
+        object_revision=0,
+        object_timestamp=0,
+        value={},
+    )
+    thermostat = _thermostat_bucket(
+        {
+            "serial_number": "thermostat-serial",
+            "rcs_source_type": RCS_SOURCE_TYPE_SINGLE_SENSOR,
+            "active_rcs_sensors": ["kryptonite.18B430"],
+        }
+    )
+    areas = {"where.hallway": "Hallway"}
+    sensor = NestThermostatActiveSensor(
+        thermostat,
+        ACTIVE_TEMPERATURE_SENSOR_DESCRIPTION,
+        areas,
+        MagicMock(),
+        {THERMOSTAT_KEY: thermostat, "kryptonite.18B430": kryptonite},
+    )
+    sensor.hass = hass
+    writes: list[str | None] = []
+    sensor.async_write_ha_state = lambda: writes.append(sensor.native_value)
+
+    # The selection is known before the sensor has published its location.
+    await sensor.async_added_to_hass()
+    assert sensor.native_value == "18B430"
+
+    # DeviceLocatedSettingsTrait lands on the sensor's own bucket.
+    kryptonite.value["where_id"] = "where.hallway"
+    async_dispatcher_send(hass, "kryptonite.18B430", kryptonite)
+    await hass.async_block_till_done()
+
+    assert writes == ["Hallway"]
+    assert sensor.native_value == "Hallway"
+
+
+async def test_active_sensor_stops_following_a_deselected_sensor(hass):
+    """Test subscriptions follow the selection instead of accumulating."""
+    thermostat = _thermostat_bucket(
+        {
+            "serial_number": "thermostat-serial",
+            "rcs_source_type": RCS_SOURCE_TYPE_SINGLE_SENSOR,
+            "active_rcs_sensors": ["kryptonite.18B430"],
+        }
+    )
+    sensor = NestThermostatActiveSensor(
+        thermostat,
+        ACTIVE_TEMPERATURE_SENSOR_DESCRIPTION,
+        {},
+        MagicMock(),
+        {THERMOSTAT_KEY: thermostat},
+    )
+    sensor.hass = hass
+    sensor.async_write_ha_state = MagicMock()
+
+    await sensor.async_added_to_hass()
+    assert set(sensor._sensor_unsubs) == {"kryptonite.18B430"}
+
+    # The thermostat switches to its own sensor.
+    thermostat.value.update(
+        {"rcs_source_type": RCS_SOURCE_TYPE_BACKPLATE, "active_rcs_sensors": []}
+    )
+    sensor.update_callback(thermostat)
+
+    assert sensor._sensor_unsubs == {}
+    assert sensor.native_value == "Thermostat"
+
+
+async def test_cached_thermostats_are_restored_before_platform_setup(hass):
+    """Test a reload recreates thermostat entities without waiting for the stream."""
+    store = MagicMock()
+    store.async_load = AsyncMock(
+        return_value={
+            THERMOSTAT_KEY: {
+                **PEER_DEVICE_VALUE,
+                "serial_number": "thermostat-serial",
+                "model": "Nest Learning Thermostat",
+            },
+            # Never cached in practice, but must not be resurrected as a device.
+            "kryptonite.18B430": {"serial_number": "sensor-serial"},
+        }
+    )
+    entry_data = _entry_data(device_store=store)
+
+    await _async_restore_protobuf_thermostats(entry_data)
+
+    assert set(entry_data.devices) == {THERMOSTAT_KEY}
+    assert entry_data.devices[THERMOSTAT_KEY].value["model"] == (
+        "Nest Learning Thermostat"
+    )
+    # Marked as announced, so live traits update the entity instead of
+    # triggering a second discovery.
+    assert entry_data.protobuf_thermostats == {THERMOSTAT_KEY}
+
+
+async def test_incomplete_cache_entries_are_ignored(hass):
+    """Test a cached thermostat without a serial number is not restored."""
+    store = MagicMock()
+    store.async_load = AsyncMock(return_value={THERMOSTAT_KEY: PEER_DEVICE_VALUE})
+    entry_data = _entry_data(device_store=store)
+
+    await _async_restore_protobuf_thermostats(entry_data)
+
+    assert entry_data.devices == {}
+    assert entry_data.protobuf_thermostats == set()
+
+
+async def test_identity_updates_are_cached_but_readings_are_not(hass):
+    """Test only identity fields are persisted, and only when they change."""
+    entry = MockConfigEntry(domain=DOMAIN)
+    store = MagicMock()
+    entry_data = _entry_data(device_store=store)
+
+    for value in (
+        PEER_DEVICE_VALUE,
+        {"serial_number": "thermostat-serial", "model": "Nest Learning Thermostat"},
+    ):
+        _apply_protobuf_device_update(
+            hass,
+            entry,
+            entry_data,
+            ProtobufDeviceUpdate(object_key=THERMOSTAT_KEY, value=value),
+        )
+
+    assert store.async_delay_save.call_count == 2
+    assert store.async_delay_save.call_args[0][0]() == {
+        THERMOSTAT_KEY: {
+            **PEER_DEVICE_VALUE,
+            "serial_number": "thermostat-serial",
+            "model": "Nest Learning Thermostat",
+        }
+    }
+
+    # A temperature update carries nothing worth persisting.
+    _apply_protobuf_device_update(
+        hass,
+        entry,
+        entry_data,
+        ProtobufDeviceUpdate(
+            object_key=THERMOSTAT_KEY, value={"backplate_temperature": 21.5}
+        ),
+    )
+
+    assert store.async_delay_save.call_count == 2
 
 
 async def test_late_identity_traits_update_the_device_registry(hass):

--- a/tests/test_thermostat.py
+++ b/tests/test_thermostat.py
@@ -306,6 +306,36 @@ def test_active_sensor_is_unknown_before_the_trait_arrives():
     }
 
 
+def test_active_sensor_name_falls_back_to_the_protobuf_where_label():
+    """Test an unmapped where_id does not drop the name back to the device id.
+
+    The protobuf located-settings trait is the only room source for a sensor
+    whose `where.` bucket has not been seen, so its literal has to be used.
+    """
+    kryptonite = Bucket(
+        object_key="kryptonite.18B430",
+        object_revision=0,
+        object_timestamp=0,
+        value={"where_id": "where.unmapped", "where_label": "Roxy"},
+    )
+    thermostat = _thermostat_bucket(
+        {
+            "serial_number": "thermostat-serial",
+            "rcs_source_type": RCS_SOURCE_TYPE_SINGLE_SENSOR,
+            "active_rcs_sensors": ["kryptonite.18B430"],
+        }
+    )
+    sensor = NestThermostatActiveSensor(
+        thermostat,
+        ACTIVE_TEMPERATURE_SENSOR_DESCRIPTION,
+        {"where.hallway": "Hallway"},
+        MagicMock(),
+        {THERMOSTAT_KEY: thermostat, "kryptonite.18B430": kryptonite},
+    )
+
+    assert sensor.native_value == "Roxy"
+
+
 async def test_active_sensor_name_resolves_when_the_sensor_traits_land(hass):
     """Test a sensor's room label arriving later replaces the bare device id."""
     kryptonite = Bucket(

--- a/uv.lock
+++ b/uv.lock
@@ -968,9 +968,25 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
 name = "ha-nest-protect"
 version = "0.4.2"
 source = { virtual = "." }
+dependencies = [
+    { name = "httpx", extra = ["http2"] },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -987,6 +1003,7 @@ test = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "httpx", extras = ["http2"], specifier = ">=0.28.1" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1141,6 +1158,15 @@ wheels = [
 ]
 
 [[package]]
+name = "hpack"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1166,6 +1192,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -949,9 +949,25 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
 name = "ha-nest-protect"
 version = "0.4.2"
 source = { virtual = "." }
+dependencies = [
+    { name = "httpx", extra = ["http2"] },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -970,6 +986,7 @@ test = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "httpx", extras = ["http2"], specifier = ">=0.28.1" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1126,6 +1143,15 @@ wheels = [
 ]
 
 [[package]]
+name = "hpack"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1151,6 +1177,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Re-implemented https://github.com/chrisjshull/homebridge-nest/ repository's support for Home/Away state in Nest. Added required support for protobuf and http2