### PR TITLE
Persist rotated Google cookies on the happy-path session refresh

### DIFF
--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -223,6 +223,12 @@ async def _async_subscribe_for_data(
 
         await sm.ensure_session()
 
+        # ensure_session refreshes the Google token roughly hourly; persist
+        # any cookies Google rotated during that refresh, otherwise every
+        # refresh replays the original cookies until Google invalidates the
+        # session (USER_LOGGED_OUT) and forces a re-authentication.
+        _persist_refreshed_cookies(hass, entry, entry_data.client, sm)
+
         result = await entry_data.client.subscribe_for_data(
             entry_data.client.nest_session.access_token,
             entry_data.client.nest_session.userid,

--- a/custom_components/nest_protect/pynest/client.py
+++ b/custom_components/nest_protect/pynest/client.py
@@ -187,6 +187,10 @@ class NestClient:
 
             if new_cookies:
                 self.refreshed_cookies = merge_cookies(cookies, new_cookies)
+                # Google rotates cookies (e.g. __Secure-1PSIDTS) and only
+                # honours stale values for a grace window; keep using the
+                # rotated set for subsequent refreshes in this session.
+                self.cookies = self.refreshed_cookies
 
             result = await response.json()
 

--- a/tests/pynest/test_client.py
+++ b/tests/pynest/test_client.py
@@ -157,6 +157,9 @@ async def test_get_access_token_from_cookies_captures_refreshed_cookies(socket_e
         assert "SID=new-sid-value" in nest_client.refreshed_cookies
         assert "HSID=new-hsid-value" in nest_client.refreshed_cookies
         assert "APISID=keep-me" in nest_client.refreshed_cookies
+        # Subsequent refreshes must replay the rotated cookies, not the
+        # originals — Google only honours stale values for a grace window.
+        assert nest_client.cookies == nest_client.refreshed_cookies
 
 
 @pytest.mark.enable_socket

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -406,6 +406,37 @@ async def test_subscriber_401_persists_refreshed_cookies(hass):
     assert client.cookies == new_cookies
 
 
+async def test_subscriber_happy_path_persists_refreshed_cookies(hass):
+    """Successful subscribe cycle persists cookies rotated during ensure_session.
+
+    Regression test: previously only the 401 path persisted rotated cookies,
+    so the hourly happy-path refresh replayed stale cookies until Google
+    invalidated the session (USER_LOGGED_OUT) and forced daily re-auth.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "issue_token": ISSUE_TOKEN,
+            "cookies": COOKIES,
+            "account_type": "production",
+        },
+    )
+    entry.add_to_hass(hass)
+    new_cookies = "SID=new-sid; HSID=new-hsid"
+    client, sm = _make_subscriber_entry_data(hass, entry, refreshed_cookies=new_cookies)
+    client.subscribe_for_data = AsyncMock(return_value={"objects": []})
+
+    with (
+        patch("custom_components.nest_protect._register_subscribe_task"),
+        patch.object(sm, "ensure_session", new_callable=AsyncMock),
+    ):
+        await _async_subscribe_for_data(hass, entry, _make_subscribe_data())
+
+    assert entry.data.get(CONF_COOKIES) == new_cookies
+    assert client.cookies == new_cookies
+    assert sm.consecutive_failures == 0
+
+
 async def test_subscriber_401_repeated_failures_triggers_reauth(hass):
     """Repeated 401s should reach MAX_AUTH_FAILURES and trigger reauth."""
     entry = MockConfigEntry(


### PR DESCRIPTION
## Problem

Multiple recent reports of the integration demanding re-authentication daily or every few hours: #481, #519, #526, #530.

Google rotates OAuth cookies (notably `__Secure-1PSIDTS`) on each token refresh, and only honours stale values for a limited grace window. The client already captures the rotated cookies into `refreshed_cookies`, but two gaps meant they were usually thrown away:

1. `NestClient.get_access_token_from_cookies` never updated `self.cookies`, so every subsequent refresh in the same HA session replayed the **original** cookies from setup.
2. `_persist_refreshed_cookies` was only called during entry setup and in the 401 recovery path — never after the roughly hourly happy-path `ensure_session()` refresh in the subscribe loop, which is where nearly all refreshes happen.

Once Google's grace window closed, the session was invalidated (`USER_LOGGED_OUT` → `BadCredentialsException` → `async_start_reauth`), producing the daily re-auth cycle. It also explains the observation in #519 that merely *reloading* the integration temporarily fixes it: the setup path is one of the two places that did persist rotated cookies.

(This is compounded by, but distinct from, the Chrome DBSC issue discussed in #526 — cookies captured from a DBSC-bound Chrome session fail regardless of this fix. Capturing cookies from Firefox/Safari plus this patch should give a long-lived session.)

## Fix

- `pynest/client.py`: after a successful cookie auth, keep the merged rotated cookie set on `self.cookies` so subsequent in-session refreshes replay the rotated values.
- `__init__.py`: call `_persist_refreshed_cookies` after `ensure_session()` in the subscribe loop, so rotations from the happy-path refresh are written back to the config entry and survive restarts.

## Tests

- New regression test `test_subscriber_happy_path_persists_refreshed_cookies` — fails on `main`, passes with this change.
- Extended `test_get_access_token_from_cookies_captures_refreshed_cookies` to assert `client.cookies` is updated to the rotated set — also fails on `main`.
- Full suite: 44 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)