### PR TITLE
Persist refreshed cookies across auth paths

### DIFF
--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -222,6 +222,7 @@ async def _async_subscribe_for_data(
         await asyncio.sleep(0)
 
         await sm.ensure_session()
+        _persist_refreshed_cookies(hass, entry, entry_data.client, sm)
 
         result = await entry_data.client.subscribe_for_data(
             entry_data.client.nest_session.access_token,

--- a/custom_components/nest_protect/config_flow.py
+++ b/custom_components/nest_protect/config_flow.py
@@ -82,11 +82,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         session = async_create_clientsession(self.hass)
         client = NestClient(session=session, environment=NEST_ENVIRONMENTS[environment])
 
-        if CONF_ISSUE_TOKEN in user_input and CONF_COOKIES in user_input:
-            issue_token = user_input[CONF_ISSUE_TOKEN]
-            cookies = user_input[CONF_COOKIES]
-        if CONF_REFRESH_TOKEN in user_input:
-            refresh_token = user_input[CONF_REFRESH_TOKEN]
+        issue_token = user_input.get(CONF_ISSUE_TOKEN)
+        cookies = user_input.get(CONF_COOKIES)
+        refresh_token = user_input.get(CONF_REFRESH_TOKEN)
 
         if issue_token and cookies:
             auth = await client.get_access_token_from_cookies(issue_token, cookies)
@@ -95,6 +93,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         nest = await client.authenticate(auth.access_token)
         data = await client.get_first_data(nest.access_token, nest.userid)
+
+        if client.refreshed_cookies:
+            cookies = client.refreshed_cookies
 
         email = ""
         for bucket in data.updated_buckets:
@@ -259,6 +260,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     [issue_token, cookies, email] = await self.async_validate_input(
                         user_input
                     )
+                    user_input[CONF_ISSUE_TOKEN] = issue_token
+                    user_input[CONF_COOKIES] = cookies
                 except TimeoutError, ClientError:
                     errors["base"] = "cannot_connect"
                 except BadCredentialsException:

--- a/custom_components/nest_protect/pynest/client.py
+++ b/custom_components/nest_protect/pynest/client.py
@@ -187,6 +187,7 @@ class NestClient:
 
             if new_cookies:
                 self.refreshed_cookies = merge_cookies(cookies, new_cookies)
+                self.cookies = self.refreshed_cookies
 
             result = await response.json()
 

--- a/custom_components/nest_protect/session.py
+++ b/custom_components/nest_protect/session.py
@@ -176,7 +176,6 @@ class NestSessionManager:
             self._client.auth.access_token
         )
         await self._async_persist(self._client.nest_session)
-        self.record_success()
         return True
 
     async def _async_persist(self, nest_session: NestResponse) -> None:

--- a/custom_components/nest_protect/session.py
+++ b/custom_components/nest_protect/session.py
@@ -160,17 +160,24 @@ class NestSessionManager:
 
         await self.async_refresh_session()
 
-    async def async_refresh_session(self) -> None:
-        """Force-refresh the Nest session via Google credentials."""
+    async def async_refresh_session(self) -> bool:
+        """Force-refresh the Nest session via Google credentials.
+
+        Returns True when a fresh Nest session was obtained and persisted.
+        """
         if not self._client.auth or self._client.auth.is_expired():
             LOGGER.debug("Retrieving new Google access token")
             await self._client.get_access_token()
 
-        if self._client.auth:
-            self._client.nest_session = await self._client.authenticate(
-                self._client.auth.access_token
-            )
-            await self._async_persist(self._client.nest_session)
+        if not self._client.auth:
+            return False
+
+        self._client.nest_session = await self._client.authenticate(
+            self._client.auth.access_token
+        )
+        await self._async_persist(self._client.nest_session)
+        self.record_success()
+        return True
 
     async def _async_persist(self, nest_session: NestResponse) -> None:
         """Save Nest session to store for reuse across restarts."""

--- a/tests/pynest/test_client.py
+++ b/tests/pynest/test_client.py
@@ -157,6 +157,7 @@ async def test_get_access_token_from_cookies_captures_refreshed_cookies(socket_e
         assert "SID=new-sid-value" in nest_client.refreshed_cookies
         assert "HSID=new-hsid-value" in nest_client.refreshed_cookies
         assert "APISID=keep-me" in nest_client.refreshed_cookies
+        assert nest_client.cookies == nest_client.refreshed_cookies
 
 
 @pytest.mark.enable_socket

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,7 +2,7 @@
 
 import base64
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -66,6 +66,55 @@ async def test_auth_method_manual_leads_to_account_link(
     assert result["step_id"] == "account_link"
 
 
+async def test_account_link_stores_refreshed_cookies(
+    hass: HomeAssistant,
+) -> None:
+    """Test manual auth stores cookies refreshed during validation."""
+    issue_token = "https://accounts.google.com/o/oauth2/iframerpc?action=issueToken&response_type=token%20id_token&login_hint=hint123&client_id=733249279899-44tchle2kaa9afr5v9ov7jbuojfr9lrq.apps.googleusercontent.com&origin=https%3A%2F%2Fhome.nest.com&scope=openid+profile+email+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fnest-account&ss_domain=https%3A%2F%2Fhome.nest.com"
+    cookies = "SID=abc123456789012345678901234567890; HSID=def1234567890; SSID=ghi1234567890; APISID=jkl1234567890; SAPISID=mno1234567890"
+    refreshed_cookies = f"{cookies}; __Secure-1PSIDTS=fresh"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"account_type": "production"},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"method": "manual"},
+    )
+
+    client = MagicMock()
+    client.refreshed_cookies = refreshed_cookies
+    client.get_access_token_from_cookies = AsyncMock(
+        return_value=MagicMock(access_token="google-token")
+    )
+    client.authenticate = AsyncMock(
+        return_value=MagicMock(access_token="nest-token", userid="user1", user="user.1")
+    )
+    client.get_first_data = AsyncMock(
+        return_value=MagicMock(
+            updated_buckets=[
+                MagicMock(object_key="user.1", value={"email": "user@example.com"})
+            ]
+        )
+    )
+
+    with patch(
+        "custom_components.nest_protect.config_flow.NestClient",
+        return_value=client,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"issue_token": issue_token, "cookies": cookies},
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"]["cookies"] == refreshed_cookies
+
+
 async def test_extension_step_creates_entry(hass: HomeAssistant) -> None:
     """Test extension step decodes code and creates entry on success."""
     issue_token = "https://accounts.google.com/o/oauth2/iframerpc?action=issueToken&response_type=token%20id_token&login_hint=hint123&client_id=733249279899-44tchle2kaa9afr5v9ov7jbuojfr9lrq.apps.googleusercontent.com&origin=https%3A%2F%2Fhome.nest.com&scope=openid+profile+email+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fnest-account&ss_domain=https%3A%2F%2Fhome.nest.com"
@@ -102,6 +151,58 @@ async def test_extension_step_creates_entry(hass: HomeAssistant) -> None:
     assert result["data"]["issue_token"] == issue_token
     assert result["data"]["cookies"] == cookies
     assert result["data"]["account_type"] == "production"
+
+
+async def test_extension_step_stores_refreshed_cookies(
+    hass: HomeAssistant,
+) -> None:
+    """Test extension step stores cookies refreshed during validation."""
+    issue_token = "https://accounts.google.com/o/oauth2/iframerpc?action=issueToken&response_type=token%20id_token&login_hint=hint123&client_id=733249279899-44tchle2kaa9afr5v9ov7jbuojfr9lrq.apps.googleusercontent.com&origin=https%3A%2F%2Fhome.nest.com&scope=openid+profile+email+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fnest-account&ss_domain=https%3A%2F%2Fhome.nest.com"
+    cookies = "SID=abc123456789012345678901234567890; HSID=def1234567890; SSID=ghi1234567890; APISID=jkl1234567890; SAPISID=mno1234567890"
+    refreshed_cookies = f"{cookies}; __Secure-1PSIDTS=fresh"
+    code = base64.b64encode(
+        json.dumps({"issue_token": issue_token, "cookies": cookies}).encode()
+    ).decode()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"account_type": "production"},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"method": "extension"},
+    )
+
+    client = MagicMock()
+    client.refreshed_cookies = refreshed_cookies
+    client.get_access_token_from_cookies = AsyncMock(
+        return_value=MagicMock(access_token="google-token")
+    )
+    client.authenticate = AsyncMock(
+        return_value=MagicMock(access_token="nest-token", userid="user1", user="user.1")
+    )
+    client.get_first_data = AsyncMock(
+        return_value=MagicMock(
+            updated_buckets=[
+                MagicMock(object_key="user.1", value={"email": "user@example.com"})
+            ]
+        )
+    )
+
+    with patch(
+        "custom_components.nest_protect.config_flow.NestClient",
+        return_value=client,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"auth_code": code},
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"]["cookies"] == refreshed_cookies
 
 
 async def test_extension_step_invalid_code(hass: HomeAssistant) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -406,6 +406,31 @@ async def test_subscriber_401_persists_refreshed_cookies(hass):
     assert client.cookies == new_cookies
 
 
+async def test_subscriber_ensure_session_persists_refreshed_cookies(hass):
+    """Proactive session refresh persists refreshed cookies before subscribing."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "issue_token": ISSUE_TOKEN,
+            "cookies": COOKIES,
+            "account_type": "production",
+        },
+    )
+    entry.add_to_hass(hass)
+    new_cookies = "SID=new-sid; HSID=new-hsid"
+    client, sm = _make_subscriber_entry_data(hass, entry, refreshed_cookies=new_cookies)
+    client.subscribe_for_data = AsyncMock(return_value={"objects": []})
+
+    with (
+        patch("custom_components.nest_protect._register_subscribe_task"),
+        patch.object(sm, "ensure_session", new_callable=AsyncMock),
+    ):
+        await _async_subscribe_for_data(hass, entry, _make_subscribe_data())
+
+    assert entry.data.get(CONF_COOKIES) == new_cookies
+    assert client.cookies == new_cookies
+
+
 async def test_subscriber_401_repeated_failures_triggers_reauth(hass):
     """Repeated 401s should reach MAX_AUTH_FAILURES and trigger reauth."""
     entry = MockConfigEntry(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -445,10 +445,16 @@ async def test_subscriber_401_repeated_failures_triggers_reauth(hass):
     client, sm = _make_subscriber_entry_data(hass, entry, consecutive_failures=0)
     client.subscribe_for_data = AsyncMock(side_effect=NotAuthenticatedException())
 
+    # Google still accepts the cookies, so the refresh itself succeeds while Nest
+    # keeps rejecting the session. async_refresh_session is deliberately not
+    # mocked here: it must not reset the failure counter it was called to recover.
+    client.auth = MagicMock(is_expired=lambda: False)
+    client.authenticate = AsyncMock(return_value=MagicMock(to_dict=dict))
+    sm._store.async_save = AsyncMock()
+
     with (
         patch("custom_components.nest_protect._register_subscribe_task"),
         patch.object(sm, "ensure_session", new_callable=AsyncMock),
-        patch.object(sm, "async_refresh_session", new_callable=AsyncMock),
         patch("custom_components.nest_protect.asyncio.sleep", new_callable=AsyncMock),
         patch.object(entry, "async_start_reauth") as mock_reauth,
     ):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -243,6 +243,7 @@ async def test_ensure_session_expired_refreshes():
     store.async_save = AsyncMock()
 
     manager = NestSessionManager(client=client, store=store)
+    manager.record_failure()
 
     await manager.ensure_session()
 
@@ -252,6 +253,8 @@ async def test_ensure_session_expired_refreshes():
     store.async_save.assert_called_once()
     # Should have set the new session on the client
     assert client.nest_session == new_session
+    # Confirmed refresh should clear stale subscriber auth failures
+    assert manager.consecutive_failures == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -243,7 +243,6 @@ async def test_ensure_session_expired_refreshes():
     store.async_save = AsyncMock()
 
     manager = NestSessionManager(client=client, store=store)
-    manager.record_failure()
 
     await manager.ensure_session()
 
@@ -253,8 +252,6 @@ async def test_ensure_session_expired_refreshes():
     store.async_save.assert_called_once()
     # Should have set the new session on the client
     assert client.nest_session == new_session
-    # Confirmed refresh should clear stale subscriber auth failures
-    assert manager.consecutive_failures == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #530

## Summary

This keeps Google-rotated cookies and subscriber auth state in sync across the remaining successful auth paths.

- Persist refreshed cookies after proactive `ensure_session()` refreshes before subscribing, not only during setup or after a subscriber 401 retry.
- Update `NestClient.cookies` immediately when `get_access_token_from_cookies()` receives `Set-Cookie` values, so later refreshes in the same Home Assistant runtime use the fresh cookie header.
- Return refreshed cookies from config-flow validation and store them for both manual auth and extension auth.
- Treat a successful `NestSessionManager.async_refresh_session()` as an auth success by resetting the subscriber consecutive-failure counter.
- Add regression coverage for subscriber refresh persistence, manual/extension config-flow storage, client cookie propagation, and refresh success clearing stale failure state.

## What changed from the previous version

The earlier issue-thread/local patch focused on preventing false reauth from subscriber failure state: timeout handling, transient subscriber errors, and retry-path persistence. Those pieces are already present on current `main`.

This PR is the follow-up from the stable version I have been running locally: it only carries the remaining auth/cookie propagation changes. It intentionally does not include unrelated local drift from my installed copy, such as entity naming changes or changing the auth-helper download URL.

## Validation

- `uv run --group dev python -m py_compile custom_components/nest_protect/__init__.py custom_components/nest_protect/config_flow.py custom_components/nest_protect/session.py custom_components/nest_protect/pynest/client.py tests/test_init.py tests/test_config_flow.py tests/test_session.py tests/pynest/test_client.py`
- `uv run --group dev ruff check custom_components/nest_protect/__init__.py custom_components/nest_protect/config_flow.py custom_components/nest_protect/session.py custom_components/nest_protect/pynest/client.py tests/test_init.py tests/test_config_flow.py tests/test_session.py tests/pynest/test_client.py`

I also attempted focused pytest locally, but on Windows the Home Assistant pytest plugin fails during startup because `homeassistant.runner` imports Unix-only `fcntl`. The same patched integration has been stable in my own Home Assistant setup since last week without the daily reauthentication issue returning.