### PR TITLE
Attempt to fix authentication recovery across restarts

### DIFF
--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from collections.abc import Mapping
 from dataclasses import dataclass, field
+from typing import Any
 
 from aiohttp import (
     ClientConnectorError,
@@ -22,13 +24,13 @@ from homeassistant.helpers.storage import Store
 
 from .const import (
     CONF_ACCOUNT_TYPE,
-    CONF_COOKIES,
-    CONF_ISSUE_TOKEN,
-    CONF_REFRESH_TOKEN,
+    CONF_AUTH_GENERATION,
+    CONF_PREVIOUS_AUTH_GENERATION,
     DOMAIN,
     LOGGER,
     PLATFORMS,
     STORAGE_KEY_FORMAT,
+    STORAGE_PENDING_REAUTH_KEY_FORMAT,
     STORAGE_VERSION,
 )
 from .lock import discovery_signal, lock_signal
@@ -48,6 +50,7 @@ from .pynest.lock_models import LockState
 from .pynest.models import (
     Bucket,
     FirstDataAPIResponse,
+    NestResponse,
     TopazBucket,
     WhereBucketValue,
 )
@@ -68,6 +71,39 @@ class HomeAssistantNestProtectData:
     lock_state_cache: dict[str, LockState] = field(default_factory=dict)
 
 
+def _active_nest_session(client: NestClient) -> NestResponse:
+    """Return the active session after the coordinator has ensured one."""
+    if client.nest_session is None:
+        raise NotAuthenticatedException("No active Nest session")
+    return client.nest_session
+
+
+async def _async_mirror_credentials(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    updates: Mapping[str, Any],
+) -> None:
+    """Mirror provider updates only while their login generation is current."""
+    update_generation = updates.get(CONF_AUTH_GENERATION)
+    current_generation = entry.data.get(CONF_AUTH_GENERATION)
+    previous_generation = updates.get(CONF_PREVIOUS_AUTH_GENERATION)
+    is_staged_handoff = (
+        isinstance(update_generation, str) and previous_generation == current_generation
+    )
+    if (
+        current_generation is not None
+        and update_generation != current_generation
+        and not is_staged_handoff
+    ):
+        LOGGER.debug("Ignoring credentials from a replaced authentication generation")
+        return
+
+    data = {**entry.data, **updates}
+    data.pop(CONF_PREVIOUS_AUTH_GENERATION, None)
+    if data != entry.data:
+        hass.config_entries.async_update_entry(entry, data=data)
+
+
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     """Migrate old Config entries."""
     LOGGER.debug("Migrating from version %s", config_entry.version)
@@ -86,23 +122,25 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Nest Protect from a config entry."""
-    issue_token = entry.data.get(CONF_ISSUE_TOKEN)
-    cookies = entry.data.get(CONF_COOKIES)
-    refresh_token = entry.data.get(CONF_REFRESH_TOKEN)
-
     session = async_create_clientsession(hass)
     account_type = entry.data.get(CONF_ACCOUNT_TYPE, Environment.PRODUCTION)
     client = NestClient(session=session, environment=NEST_ENVIRONMENTS[account_type])
-
-    client.issue_token = issue_token
-    client.cookies = cookies
-    client.refresh_token = refresh_token
 
     store = Store(
         hass, STORAGE_VERSION, STORAGE_KEY_FORMAT.format(entry_id=entry.entry_id)
     )
 
-    session_manager = NestSessionManager(client=client, store=store)
+    async def async_update_credentials(updates: Mapping[str, Any]) -> None:
+        """Mirror durable provider updates into the config entry."""
+        await _async_mirror_credentials(hass, entry, updates)
+
+    session_manager = NestSessionManager(
+        client=client,
+        store=store,
+        credential_generation=entry.data.get(CONF_AUTH_GENERATION),
+        credential_update_callback=async_update_credentials,
+        initial_credentials=entry.data,
+    )
 
     try:
         data = await session_manager.async_setup()
@@ -117,8 +155,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     if data is None:
         raise ConfigEntryAuthFailed("No credentials available")
 
-    # Update cookies in config entry if Google returned refreshed ones
-    _persist_refreshed_cookies(hass, entry, client, session_manager)
+    session_manager.set_reauthentication_callback(
+        lambda: entry.async_start_reauth(hass)
+    )
 
     device_buckets: list[Bucket] = []
     areas: dict[str, str] = {}
@@ -166,7 +205,7 @@ async def _async_observe_locks_loop(hass: HomeAssistant, entry: ConfigEntry) -> 
     Returns — ending the background task — when the observer reports that this
     account has no locks, so accounts without a Nest x Yale lock stop talking to
     the gateway after the first stream. Auth failures are retried with a session
-    refresh, and escalate to re-auth after MAX_AUTH_FAILURES.
+    refresh and escalate only after the configured credentials are rejected.
 
     Auth health is tracked on the shared NestSessionManager rather than locally,
     so this loop and the REST subscriber can't each sit below the threshold
@@ -177,10 +216,11 @@ async def _async_observe_locks_loop(hass: HomeAssistant, entry: ConfigEntry) -> 
     sm = entry_data.session_manager
 
     while True:
+        rejected_session = sm.current_session
         try:
-            async for batch in entry_data.grpc_lock_client.observe_locks():
-                # A working stream clears failures recorded by either transport.
-                sm.record_success()
+            async for batch in entry_data.grpc_lock_client.observe_locks(
+                nest_session=rejected_session
+            ):
                 new_locks: dict[str, LockState] = {}
                 for resource_id, lock_state in batch.items():
                     previous = cache.get(resource_id)
@@ -198,27 +238,26 @@ async def _async_observe_locks_loop(hass: HomeAssistant, entry: ConfigEntry) -> 
         except asyncio.CancelledError:
             raise
         except NestLockAuthException as err:
-            sm.record_failure()
-            if sm.should_trigger_reauth:
-                LOGGER.warning(
-                    "Lock observer: %d consecutive auth failures, triggering "
-                    "re-authentication",
-                    sm.consecutive_failures,
-                )
-                entry.async_start_reauth(hass)
-                return
-
             LOGGER.debug(
-                "Lock observer: credentials rejected (%r), refreshing session", err
+                "Lock observer: session rejected (%r), refreshing session", err
             )
-            await asyncio.sleep(sm.backoff_interval)
-            await sm.async_refresh_session()
-
-            # Entry may have been unloaded during the backoff sleep
-            if entry.entry_id not in hass.data.get(DOMAIN, {}):
+            try:
+                await sm.async_refresh_session(rejected_session=rejected_session)
+            except BadCredentialsException:
+                sm.request_reauthentication()
                 return
-
-            _persist_refreshed_cookies(hass, entry, entry_data.client, sm)
+            except (
+                TimeoutError,
+                ClientError,
+                NestServiceException,
+                NotAuthenticatedException,
+                PynestException,
+            ) as refresh_error:
+                LOGGER.debug(
+                    "Lock observer: session recovery failed temporarily: %r",
+                    refresh_error,
+                )
+                await asyncio.sleep(60)
         except Exception:
             LOGGER.exception("Lock observe loop failed unexpectedly")
             return
@@ -253,32 +292,13 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     store = Store(
         hass, STORAGE_VERSION, STORAGE_KEY_FORMAT.format(entry_id=entry.entry_id)
     )
-    await store.async_remove()
-
-
-def _persist_refreshed_cookies(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
-    client: NestClient,
-    sm: NestSessionManager,
-) -> None:
-    """Persist Google-rotated cookies back to the config entry and client.
-
-    Google may rotate OAuth cookies during ``get_access_token_from_cookies``.
-    Without writing them back, a HA restart would use stale cookies and force
-    re-authentication; the in-memory client also needs the update so the next
-    refresh in the same HA session uses fresh cookies.
-    """
-    new_cookies = sm.refreshed_cookies
-    if not new_cookies or new_cookies == entry.data.get(CONF_COOKIES):
-        return
-
-    LOGGER.debug("Persisting refreshed Nest cookies")
-    hass.config_entries.async_update_entry(
-        entry,
-        data={**entry.data, CONF_COOKIES: new_cookies},
+    pending_reauth_store = Store(
+        hass,
+        STORAGE_VERSION,
+        STORAGE_PENDING_REAUTH_KEY_FORMAT.format(entry_id=entry.entry_id),
     )
-    client.cookies = new_cookies
+    await store.async_remove()
+    await pending_reauth_store.async_remove()
 
 
 def _register_subscribe_task(
@@ -304,21 +324,21 @@ async def _async_subscribe_for_data(
 
     entry_data: HomeAssistantNestProtectData = hass.data[DOMAIN][entry.entry_id]
     sm = entry_data.session_manager
+    rejected_session: NestResponse | None = None
 
     try:
         await asyncio.sleep(0)
 
         await sm.ensure_session()
-        _persist_refreshed_cookies(hass, entry, entry_data.client, sm)
+        session = _active_nest_session(entry_data.client)
+        rejected_session = session
 
         result = await entry_data.client.subscribe_for_data(
-            entry_data.client.nest_session.access_token,
-            entry_data.client.nest_session.userid,
+            session.access_token,
+            session.userid,
             data.service_urls["urls"]["transport_url"],
             data.updated_buckets,
         )
-
-        sm.record_success()
 
         # TODO write this data away in a better way, best would be to directly model API responses in client
         for bucket in result["objects"]:
@@ -372,7 +392,6 @@ async def _async_subscribe_for_data(
 
     except asyncio.exceptions.TimeoutError:
         LOGGER.debug("Subscriber: session timed out.")
-        sm.record_success()
         _register_subscribe_task(hass, entry, data)
 
     except ClientConnectorError:
@@ -389,30 +408,27 @@ async def _async_subscribe_for_data(
 
     except NotAuthenticatedException:
         LOGGER.debug("Subscriber: 401 exception.")
-        sm.record_failure()
-
-        if sm.should_trigger_reauth:
-            LOGGER.warning(
-                "Subscriber: %d consecutive auth failures, triggering re-authentication",
-                sm.consecutive_failures,
-            )
-            entry.async_start_reauth(hass)
+        try:
+            await sm.async_refresh_session(rejected_session=rejected_session)
+        except BadCredentialsException:
+            sm.request_reauthentication()
             return
-
-        LOGGER.debug(
-            "Subscriber: retrying in %ds (attempt %d)",
-            sm.backoff_interval,
-            sm.consecutive_failures,
-        )
-        await asyncio.sleep(sm.backoff_interval)
-
-        await sm.async_refresh_session()
+        except (
+            TimeoutError,
+            ClientError,
+            NestServiceException,
+            NotAuthenticatedException,
+            PynestException,
+        ) as refresh_error:
+            LOGGER.debug(
+                "Subscriber: session recovery failed temporarily: %r",
+                refresh_error,
+            )
+            await asyncio.sleep(60)
 
         # Entry may have been unloaded during the backoff sleep
         if entry.entry_id not in hass.data.get(DOMAIN, {}):
             return
-
-        _persist_refreshed_cookies(hass, entry, entry_data.client, sm)
 
         _register_subscribe_task(hass, entry, data)
 
@@ -420,7 +436,7 @@ async def _async_subscribe_for_data(
         LOGGER.warning(
             "Bad credentials detected. Please re-authenticate the Nest Protect integration."
         )
-        entry.async_start_reauth(hass)
+        sm.request_reauthentication()
         return
 
     except NestServiceException:
@@ -440,12 +456,10 @@ async def _async_subscribe_for_data(
         raise
 
     except Exception:  # pylint: disable=broad-except
-        sm.record_failure()
         LOGGER.exception(
-            "Unknown exception. Please create an issue on GitHub with your logfile. Updates paused for %ds.",
-            sm.backoff_interval,
+            "Unknown exception. Please create an issue on GitHub with your logfile. Updates paused for 60s.",
         )
-        await asyncio.sleep(sm.backoff_interval)
+        await asyncio.sleep(60)
         _register_subscribe_task(hass, entry, data)
 
 

--- a/custom_components/nest_protect/config_flow.py
+++ b/custom_components/nest_protect/config_flow.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any, cast
 
 import voluptuous as vol
@@ -12,20 +16,33 @@ from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
+from homeassistant.helpers.storage import Store
 
 from .const import (
     CONF_ACCOUNT_TYPE,
     CONF_AUTH_CODE,
+    CONF_AUTH_GENERATION,
     CONF_COOKIES,
     CONF_ISSUE_TOKEN,
-    CONF_REFRESH_TOKEN,
     DOMAIN,
     LOGGER,
+    STORAGE_KEY_FORMAT,
+    STORAGE_PENDING_REAUTH_KEY_FORMAT,
+    STORAGE_VERSION,
+)
+from .credentials import (
+    apply_credential_updates,
+    create_credential_providers,
+    credential_field_names,
 )
 from .pynest.client import NestClient
 from .pynest.const import NEST_ENVIRONMENTS
 from .pynest.enums import Environment
 from .pynest.exceptions import BadCredentialsException
+from .session import (
+    async_authenticate_with_providers_once,
+    build_reauthentication_state,
+)
 
 DESCRIPTION_PLACEHOLDERS = {
     "nest_url": "https://home.nest.com",
@@ -37,6 +54,15 @@ DESCRIPTION_PLACEHOLDERS = {
 }
 
 
+@dataclass(frozen=True)
+class ConfigFlowValidationResult:
+    """Validated provider credentials and the Nest account they access."""
+
+    credentials: dict[str, Any]
+    credential_fields: frozenset[str]
+    email: str
+
+
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for Nest Protect."""
 
@@ -44,6 +70,38 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     _config_entry: ConfigEntry | None = None
     _default_account_type: Environment = Environment.PRODUCTION
+    _pending_credential_source_fingerprint: str | None = None
+    _pending_credential_updates: dict[str, Any] | None = None
+
+    def _pending_reauthentication_store(self) -> Store | None:
+        """Return durable scratch storage while reauthentication is validated."""
+        if self._config_entry is None:
+            return None
+        return Store(
+            self.hass,
+            STORAGE_VERSION,
+            STORAGE_PENDING_REAUTH_KEY_FORMAT.format(
+                entry_id=self._config_entry.entry_id
+            ),
+        )
+
+    @staticmethod
+    def _credential_source_fingerprint(
+        environment: Any,
+        credentials: Mapping[str, Any],
+        auth_generation: Any,
+    ) -> str:
+        """Identify the submitted credential set without storing another copy."""
+        serialized = json.dumps(
+            {
+                "environment": environment,
+                "credentials": credentials,
+                "auth_generation": auth_generation,
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        return hashlib.sha256(serialized.encode()).hexdigest()
 
     @staticmethod
     def _validate_issue_token(issue_token: str) -> bool:
@@ -75,38 +133,153 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         google_auth_markers = ("APISID=", "SAPISID=", "HSID=", "SSID=", "SID=")
         return any(marker in cookies for marker in google_auth_markers)
 
-    async def async_validate_input(self, user_input: dict[str, Any]) -> list:
+    async def async_validate_input(
+        self, user_input: dict[str, Any]
+    ) -> ConfigFlowValidationResult:
         """Validate user credentials."""
 
         environment = user_input[CONF_ACCOUNT_TYPE]
         session = async_create_clientsession(self.hass)
         client = NestClient(session=session, environment=NEST_ENVIRONMENTS[environment])
 
-        issue_token = user_input.get(CONF_ISSUE_TOKEN)
-        cookies = user_input.get(CONF_COOKIES)
-        refresh_token = user_input.get(CONF_REFRESH_TOKEN)
+        pending_store = self._pending_reauthentication_store()
+        entry_generation = (
+            self._config_entry.data.get(CONF_AUTH_GENERATION)
+            if self._config_entry is not None
+            else None
+        )
+        pending_updates: dict[str, Any] = {}
+        credential_source_fingerprint = ""
 
-        if issue_token and cookies:
-            auth = await client.get_access_token_from_cookies(issue_token, cookies)
-        elif refresh_token:
-            auth = await client.get_access_token_from_refresh_token(refresh_token)
+        async def capture_credential_updates(updates) -> None:
+            pending_updates.update(updates)
+            if pending_store is not None:
+                await pending_store.async_save(
+                    {
+                        "source": credential_source_fingerprint,
+                        "generation": entry_generation,
+                        "updates": dict(pending_updates),
+                    }
+                )
 
-        nest = await client.authenticate(auth.access_token)
-        data = await client.get_first_data(nest.access_token, nest.userid)
+        providers = create_credential_providers(
+            client,
+            capture_credential_updates,
+        )
+        fields = credential_field_names(providers)
+        submitted_credentials = {
+            field: user_input[field] for field in fields if field in user_input
+        }
+        credential_inputs = {
+            field: submitted_credentials.get(field) for field in fields
+        }
+        credential_source_fingerprint = self._credential_source_fingerprint(
+            environment,
+            credential_inputs,
+            entry_generation,
+        )
+        if credential_source_fingerprint != self._pending_credential_source_fingerprint:
+            self._pending_credential_source_fingerprint = credential_source_fingerprint
+            self._pending_credential_updates = {}
 
-        if client.refreshed_cookies:
-            cookies = client.refreshed_cookies
+        if self._pending_credential_updates is not None:
+            pending_updates.update(self._pending_credential_updates)
+
+        if pending_store is not None:
+            persisted_pending = await pending_store.async_load()
+            if (
+                isinstance(persisted_pending, dict)
+                and persisted_pending.get("source") == credential_source_fingerprint
+                and persisted_pending.get("generation") == entry_generation
+                and isinstance(persisted_pending.get("updates"), dict)
+            ):
+                pending_updates.update(persisted_pending["updates"])
+
+        self._pending_credential_updates = pending_updates
+        apply_credential_updates(
+            client,
+            {**credential_inputs, **pending_updates},
+            fields,
+        )
+
+        if not any(provider.available for provider in providers):
+            raise BadCredentialsException("No credentials available")
+
+        result = await async_authenticate_with_providers_once(client, providers)
+        credentials = {**submitted_credentials, **pending_updates}
 
         email = ""
-        for bucket in data.updated_buckets:
+        for bucket in result.data.updated_buckets:
             key = bucket.object_key
             if key.startswith("user."):
                 email = bucket.value["email"]
 
         # Set unique id to user_id (object.key: user.xxxx)
-        await self.async_set_unique_id(nest.user)
+        await self.async_set_unique_id(result.session.user)
 
-        return [issue_token, cookies, email]
+        return ConfigFlowValidationResult(credentials, fields, email)
+
+    async def _async_finish_reauthentication(
+        self,
+        data: dict[str, Any],
+        credential_fields: frozenset[str],
+    ) -> FlowResult:
+        """Replace credentials without restoring state from the old login."""
+        if self._config_entry is None:
+            raise RuntimeError("Reauthentication entry is not available")
+
+        previous_generation = self._config_entry.data.get(CONF_AUTH_GENERATION)
+        credential_generation = uuid.uuid4().hex
+        updated_data = {
+            **{
+                key: value
+                for key, value in self._config_entry.data.items()
+                if key not in credential_fields
+            },
+            **data,
+            CONF_AUTH_GENERATION: credential_generation,
+        }
+        credentials = {
+            key: updated_data[key] for key in credential_fields if key in updated_data
+        }
+
+        entry_data = self.hass.data.get(DOMAIN, {}).get(self._config_entry.entry_id)
+        session_manager = getattr(entry_data, "session_manager", None)
+        if session_manager is not None:
+            await session_manager.async_stage_reauthentication(
+                credential_generation,
+                credentials,
+            )
+        else:
+            store = Store(
+                self.hass,
+                STORAGE_VERSION,
+                STORAGE_KEY_FORMAT.format(entry_id=self._config_entry.entry_id),
+            )
+            current_state = await store.async_load()
+            await store.async_save(
+                build_reauthentication_state(
+                    current_state if isinstance(current_state, dict) else {},
+                    credential_generation,
+                    previous_generation,
+                    credentials,
+                )
+            )
+
+        self.hass.config_entries.async_update_entry(
+            self._config_entry,
+            data=updated_data,
+        )
+        self.hass.async_create_task(
+            self.hass.config_entries.async_reload(self._config_entry.entry_id)
+        )
+        pending_store = self._pending_reauthentication_store()
+        if pending_store is not None:
+            try:
+                await pending_store.async_remove()
+            except OSError:
+                LOGGER.warning("Could not remove pending reauthentication data")
+        return self.async_abort(reason="reauth_successful")
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -188,9 +361,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_ACCOUNT_TYPE: self._default_account_type,
                 }
                 try:
-                    [issue_token, cookies, email] = await self.async_validate_input(
-                        validation_input
-                    )
+                    validated = await self.async_validate_input(validation_input)
                 except TimeoutError, ClientError:
                     errors["base"] = "cannot_connect"
                 except BadCredentialsException:
@@ -201,26 +372,18 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             if not errors:
                 data = {
-                    CONF_ISSUE_TOKEN: issue_token,
-                    CONF_COOKIES: cookies,
+                    **validated.credentials,
                     CONF_ACCOUNT_TYPE: self._default_account_type,
                 }
 
                 if self._config_entry:
-                    self.hass.config_entries.async_update_entry(
-                        self._config_entry,
-                        data={**self._config_entry.data, **data},
+                    return await self._async_finish_reauthentication(
+                        data, validated.credential_fields
                     )
-                    self.hass.async_create_task(
-                        self.hass.config_entries.async_reload(
-                            self._config_entry.entry_id
-                        )
-                    )
-                    return self.async_abort(reason="reauth_successful")
 
                 self._abort_if_unique_id_configured()
                 return self.async_create_entry(
-                    title=f"Nest Protect ({email})", data=data
+                    title=f"Nest Protect ({validated.email})", data=data
                 )
 
         return self.async_show_form(
@@ -257,11 +420,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             if not errors:
                 try:
-                    [issue_token, cookies, email] = await self.async_validate_input(
-                        user_input
-                    )
-                    user_input[CONF_ISSUE_TOKEN] = issue_token
-                    user_input[CONF_COOKIES] = cookies
+                    validated = await self.async_validate_input(user_input)
                 except TimeoutError, ClientError:
                     errors["base"] = "cannot_connect"
                 except BadCredentialsException:
@@ -271,28 +430,19 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     LOGGER.exception(exception)
 
             if not errors:
+                data = {
+                    **validated.credentials,
+                    CONF_ACCOUNT_TYPE: self._default_account_type,
+                }
                 if self._config_entry:
-                    # Update existing entry during reauth
-                    self.hass.config_entries.async_update_entry(
-                        self._config_entry,
-                        data={
-                            **self._config_entry.data,
-                            **user_input,
-                        },
+                    return await self._async_finish_reauthentication(
+                        data, validated.credential_fields
                     )
-
-                    self.hass.async_create_task(
-                        self.hass.config_entries.async_reload(
-                            self._config_entry.entry_id
-                        )
-                    )
-
-                    return self.async_abort(reason="reauth_successful")
 
                 self._abort_if_unique_id_configured()
 
                 return self.async_create_entry(
-                    title=f"Nest Protect ({email})", data=user_input
+                    title=f"Nest Protect ({validated.email})", data=data
                 )
 
         return self.async_show_form(

--- a/custom_components/nest_protect/const.py
+++ b/custom_components/nest_protect/const.py
@@ -17,6 +17,8 @@ CONF_REFRESH_TOKEN: Final = "refresh_token"
 CONF_ISSUE_TOKEN: Final = "issue_token"
 CONF_COOKIES: Final = "cookies"
 CONF_AUTH_CODE: Final = "auth_code"
+CONF_AUTH_GENERATION: Final = "auth_generation"
+CONF_PREVIOUS_AUTH_GENERATION: Final = "previous_auth_generation"
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
@@ -28,6 +30,6 @@ PLATFORMS: list[Platform] = [
 
 STORAGE_VERSION: Final = 1
 STORAGE_KEY_FORMAT: Final = "nest_protect_{entry_id}"
+STORAGE_PENDING_REAUTH_KEY_FORMAT: Final = "nest_protect_pending_reauth_{entry_id}"
 SESSION_EXPIRY_BUFFER_SECONDS: Final = 300  # 5 minutes
-MAX_AUTH_FAILURES: Final = 3
-BACKOFF_INTERVALS: Final = (30, 60, 120, 300, 600)  # seconds, capped at 10 min
+AUTH_RETRY_DELAYS: Final = (1, 5, 30)

--- a/custom_components/nest_protect/credentials.py
+++ b/custom_components/nest_protect/credentials.py
@@ -1,0 +1,123 @@
+"""Credential providers for Google access tokens."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Collection, Mapping, Sequence
+from typing import Any, Protocol
+
+from .const import CONF_COOKIES, CONF_ISSUE_TOKEN, CONF_REFRESH_TOKEN
+from .pynest.client import NestClient
+from .pynest.models import GoogleAuthResponse
+
+CredentialUpdateCallback = Callable[[Mapping[str, Any]], Awaitable[None]]
+
+
+class CredentialProvider(Protocol):
+    """Acquire Google access tokens using one credential method."""
+
+    name: str
+    credential_fields: frozenset[str]
+
+    @property
+    def available(self) -> bool:
+        """Return whether this provider has the credentials it requires."""
+
+    async def async_get_access_token(self) -> GoogleAuthResponse:
+        """Return a Google access token."""
+
+
+class CookieCredentialProvider:
+    """Acquire Google access tokens from an issue token and cookies."""
+
+    name = "cookies"
+    credential_fields = frozenset({CONF_ISSUE_TOKEN, CONF_COOKIES})
+
+    def __init__(
+        self,
+        client: NestClient,
+        async_save_credentials: CredentialUpdateCallback,
+    ) -> None:
+        """Initialize the cookie provider."""
+        self._client = client
+        self._async_save_credentials = async_save_credentials
+
+    @property
+    def available(self) -> bool:
+        """Return whether cookie credentials are available."""
+        return bool(self._client.issue_token and self._client.cookies)
+
+    async def async_get_access_token(self) -> GoogleAuthResponse:
+        """Acquire a token and durably report response-side cookie rotation."""
+        issue_token = self._client.issue_token
+        cookies = self._client.cookies
+        if not issue_token or not cookies:
+            raise ValueError("Cookie credentials are not available")
+
+        try:
+            return await self._client.get_access_token_from_cookies(
+                issue_token, cookies
+            )
+        finally:
+            refreshed = self._client.refreshed_cookies
+            if refreshed and refreshed != cookies:
+                await self._async_save_credentials({CONF_COOKIES: refreshed})
+
+
+class RefreshTokenCredentialProvider:
+    """Acquire Google access tokens from a legacy refresh token."""
+
+    name = "refresh_token"
+    credential_fields = frozenset({CONF_REFRESH_TOKEN})
+
+    def __init__(
+        self,
+        client: NestClient,
+        async_save_credentials: CredentialUpdateCallback,
+    ) -> None:
+        """Initialize the refresh-token provider."""
+        self._client = client
+        self._async_save_credentials = async_save_credentials
+
+    @property
+    def available(self) -> bool:
+        """Return whether a refresh token is available."""
+        return bool(self._client.refresh_token)
+
+    async def async_get_access_token(self) -> GoogleAuthResponse:
+        """Acquire an access token from a legacy refresh token."""
+        refresh_token = self._client.refresh_token
+        if not refresh_token:
+            raise ValueError("Refresh-token credentials are not available")
+
+        return await self._client.get_access_token_from_refresh_token(refresh_token)
+
+
+def create_credential_providers(
+    client: NestClient,
+    async_save_credentials: CredentialUpdateCallback,
+) -> Sequence[CredentialProvider]:
+    """Create providers in stable fallback order."""
+    return (
+        CookieCredentialProvider(client, async_save_credentials),
+        RefreshTokenCredentialProvider(client, async_save_credentials),
+    )
+
+
+def credential_field_names(
+    providers: Sequence[CredentialProvider],
+) -> frozenset[str]:
+    """Return every config field owned by the registered providers."""
+    return frozenset(
+        field for provider in providers for field in provider.credential_fields
+    )
+
+
+def apply_credential_updates(
+    client: NestClient,
+    updates: Mapping[str, Any],
+    credential_fields: Collection[str],
+) -> None:
+    """Apply durable credential fields to the live client."""
+    for field in credential_fields:
+        if field in updates:
+            setattr(client, field, updates[field])

--- a/custom_components/nest_protect/diagnostics.py
+++ b/custom_components/nest_protect/diagnostics.py
@@ -11,8 +11,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry
 
 from . import HomeAssistantNestProtectData
-from .const import CONF_COOKIES, CONF_ISSUE_TOKEN, CONF_REFRESH_TOKEN, DOMAIN
+from .const import DOMAIN
 from .pynest.const import FULL_NEST_REQUEST
+from .pynest.exceptions import NotAuthenticatedException
+from .pynest.models import FirstDataAPIResponse
 
 TO_REDACT = [
     "access_token",
@@ -48,35 +50,53 @@ TO_REDACT = [
 ]
 
 
+async def _async_get_first_data(
+    entry_data: HomeAssistantNestProtectData,
+    *,
+    request: dict[str, Any] | None = None,
+) -> FirstDataAPIResponse:
+    """Fetch diagnostics data, retrying the exact session rejected by Nest."""
+    client = entry_data.client
+    manager = entry_data.session_manager
+    await manager.ensure_session()
+    session = client.nest_session
+    if session is None:
+        raise NotAuthenticatedException("No active Nest session")
+
+    try:
+        if request is None:
+            return await client.get_first_data(session.access_token, session.userid)
+        return await client.get_first_data(
+            session.access_token, session.userid, request=request
+        )
+    except NotAuthenticatedException:
+        await manager.async_refresh_session(rejected_session=session)
+
+    replacement = client.nest_session
+    if replacement is None:
+        raise NotAuthenticatedException("Nest session recovery failed")
+    try:
+        if request is None:
+            return await client.get_first_data(
+                replacement.access_token, replacement.userid
+            )
+        return await client.get_first_data(
+            replacement.access_token, replacement.userid, request=request
+        )
+    except NotAuthenticatedException:
+        await manager.async_invalidate_session(rejected_session=replacement)
+        raise
+
+
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    issue_token = None
-    cookies = None
-    refresh_token = None
-
-    if CONF_ISSUE_TOKEN in entry.data and CONF_COOKIES in entry.data:
-        issue_token = entry.data[CONF_ISSUE_TOKEN]
-        cookies = entry.data[CONF_COOKIES]
-    if CONF_REFRESH_TOKEN in entry.data:
-        refresh_token = entry.data[CONF_REFRESH_TOKEN]
-
     entry_data: HomeAssistantNestProtectData = hass.data[DOMAIN][entry.entry_id]
-    client = entry_data.client
-
-    if issue_token and cookies:
-        auth = await client.get_access_token_from_cookies(issue_token, cookies)
-    elif refresh_token:
-        auth = await client.get_access_token_from_refresh_token(refresh_token)
-
-    nest = await client.authenticate(auth.access_token)
 
     data = {
         "app_launch": dataclasses.asdict(
-            await client.get_first_data(
-                nest.access_token, nest.userid, request=FULL_NEST_REQUEST
-            )
+            await _async_get_first_data(entry_data, request=FULL_NEST_REQUEST)
         )
     }
 
@@ -87,25 +107,7 @@ async def async_get_device_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry, device: DeviceEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a device entry."""
-    issue_token = None
-    cookies = None
-    refresh_token = None
-
-    if CONF_ISSUE_TOKEN in entry.data and CONF_COOKIES in entry.data:
-        issue_token = entry.data[CONF_ISSUE_TOKEN]
-        cookies = entry.data[CONF_COOKIES]
-    if CONF_REFRESH_TOKEN in entry.data:
-        refresh_token = entry.data[CONF_REFRESH_TOKEN]
-
     entry_data: HomeAssistantNestProtectData = hass.data[DOMAIN][entry.entry_id]
-    client = entry_data.client
-
-    if issue_token and cookies:
-        auth = await client.get_access_token_from_cookies(issue_token, cookies)
-    elif refresh_token:
-        auth = await client.get_access_token_from_refresh_token(refresh_token)
-
-    nest = await client.authenticate(auth.access_token)
 
     data = {
         "device": {
@@ -113,9 +115,7 @@ async def async_get_device_diagnostics(
             "firmware": device.sw_version,
             "model": device.model,
         },
-        "app_launch": dataclasses.asdict(
-            await client.get_first_data(nest.access_token, nest.userid)
-        ),
+        "app_launch": dataclasses.asdict(await _async_get_first_data(entry_data)),
     }
 
     return async_redact_data(data, TO_REDACT)

--- a/custom_components/nest_protect/entity.py
+++ b/custom_components/nest_protect/entity.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.entity import DeviceInfo, Entity, EntityDescription
 
 from .const import ATTRIBUTION, DOMAIN
 from .pynest.client import NestClient
+from .pynest.exceptions import NotAuthenticatedException
 from .pynest.models import Bucket
 
 if TYPE_CHECKING:
@@ -154,9 +155,33 @@ class NestUpdatableEntity(NestDescriptiveEntity):
     async def _async_update_objects(self, objects: list[dict]) -> dict:
         """Update objects with automatic session refresh."""
         await self.session_manager.ensure_session()
-        return await self.client.update_objects(
-            self.client.nest_session.access_token,
-            self.client.nest_session.userid,
-            self.client.transport_url,
-            objects,
-        )
+        session = self.client.nest_session
+        if session is None:
+            raise NotAuthenticatedException("No active Nest session")
+
+        try:
+            return await self.client.update_objects(
+                session.access_token,
+                session.userid,
+                self.client.transport_url,
+                objects,
+            )
+        except NotAuthenticatedException:
+            await self.session_manager.async_refresh_session(rejected_session=session)
+
+        session = self.client.nest_session
+        if session is None:
+            raise NotAuthenticatedException("Nest session recovery failed")
+
+        try:
+            return await self.client.update_objects(
+                session.access_token,
+                session.userid,
+                self.client.transport_url,
+                objects,
+            )
+        except NotAuthenticatedException:
+            await self.session_manager.async_invalidate_session(
+                rejected_session=session
+            )
+            raise

--- a/custom_components/nest_protect/lock.py
+++ b/custom_components/nest_protect/lock.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from aiohttp import ClientError
 from homeassistant.components.lock import LockEntity
@@ -22,9 +22,18 @@ from homeassistant.helpers.entity import DeviceInfo, Entity, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import ATTRIBUTION, DOMAIN
-from .pynest.exceptions import PynestException
+from .pynest.exceptions import (
+    BadCredentialsException,
+    NestLockAuthException,
+    NestServiceException,
+    NotAuthenticatedException,
+    PynestException,
+)
 from .pynest.grpc_client import GrpcLockClient
 from .pynest.lock_models import LockBoltState, LockState
+
+if TYPE_CHECKING:
+    from .session import NestSessionManager
 
 LOCK_SIGNAL_PREFIX = "nest_protect_lock_"
 
@@ -97,12 +106,13 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up lock entities. Discovery is event-driven via dispatcher."""
-    grpc_client = hass.data[DOMAIN][entry.entry_id].grpc_lock_client
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    grpc_client = entry_data.grpc_lock_client
     subscribe_to_lock_discovery(
         hass,
         entry,
         async_add_entities,
-        lambda state: NestLockEntity(grpc_client, state),
+        lambda state: NestLockEntity(grpc_client, state, entry_data.session_manager),
     )
 
 
@@ -113,10 +123,16 @@ class NestLockEntity(LockEntity):
     _attr_should_poll = False
     _attr_name = None  # The lock is the primary feature of the device
 
-    def __init__(self, grpc_client: GrpcLockClient, lock_state: LockState) -> None:
+    def __init__(
+        self,
+        grpc_client: GrpcLockClient,
+        lock_state: LockState,
+        session_manager: NestSessionManager,
+    ) -> None:
         """Initialize."""
         self._grpc_client = grpc_client
         self._lock_state = lock_state
+        self._session_manager = session_manager
         self._attr_unique_id = f"lock_{lock_state.resource_id}"
         self._attr_attribution = ATTRIBUTION
         self._attr_device_info = self._build_device_info()
@@ -192,20 +208,59 @@ class NestLockEntity(LockEntity):
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the lock."""
         try:
-            await self._grpc_client.send_lock_command(
-                self._lock_state.resource_id, lock=True
-            )
-        except (ClientError, TimeoutError, PynestException) as err:
+            await self._async_send_command(lock=True)
+        except (
+            ClientError,
+            TimeoutError,
+            BadCredentialsException,
+            NestServiceException,
+            NotAuthenticatedException,
+            PynestException,
+        ) as err:
             raise HomeAssistantError(f"Failed to lock: {err}") from err
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock."""
         try:
-            await self._grpc_client.send_lock_command(
-                self._lock_state.resource_id, lock=False
-            )
-        except (ClientError, TimeoutError, PynestException) as err:
+            await self._async_send_command(lock=False)
+        except (
+            ClientError,
+            TimeoutError,
+            BadCredentialsException,
+            NestServiceException,
+            NotAuthenticatedException,
+            PynestException,
+        ) as err:
             raise HomeAssistantError(f"Failed to unlock: {err}") from err
+
+    async def _async_send_command(self, *, lock: bool) -> None:
+        """Send a command and retry once after coordinated session recovery."""
+        await self._session_manager.ensure_session()
+        rejected_session = self._session_manager.current_session
+
+        try:
+            await self._grpc_client.send_lock_command(
+                self._lock_state.resource_id,
+                lock=lock,
+                nest_session=rejected_session,
+            )
+        except NestLockAuthException:
+            await self._session_manager.async_refresh_session(
+                rejected_session=rejected_session
+            )
+            replacement_session = self._session_manager.current_session
+            try:
+                await self._grpc_client.send_lock_command(
+                    self._lock_state.resource_id,
+                    lock=lock,
+                    nest_session=replacement_session,
+                )
+            except NestLockAuthException:
+                if replacement_session is not None:
+                    await self._session_manager.async_invalidate_session(
+                        rejected_session=replacement_session
+                    )
+                raise
 
 
 class NestLockBatterySensor(SensorEntity):

--- a/custom_components/nest_protect/pynest/client.py
+++ b/custom_components/nest_protect/pynest/client.py
@@ -8,7 +8,13 @@ from random import randint
 from types import TracebackType
 from typing import Any, cast
 
-from aiohttp import ClientSession, ClientTimeout, ContentTypeError, FormData
+from aiohttp import (
+    ClientResponse,
+    ClientSession,
+    ClientTimeout,
+    ContentTypeError,
+    FormData,
+)
 
 from .const import (
     APP_LAUNCH_URL_FORMAT,
@@ -38,6 +44,72 @@ from .models import (
 )
 
 _LOGGER = logging.getLogger(__package__)
+
+_AUTH_ERROR_CODES = frozenset(
+    {"access_denied", "not_authenticated", "unauthorized", "user_logged_out"}
+)
+_GOOGLE_CREDENTIAL_ERROR_CODES = frozenset(
+    {"access_denied", "invalid_grant", "user_logged_out"}
+)
+
+
+async def _raise_for_nest_status(response: ClientResponse, *, action: str) -> None:
+    """Classify HTTP failures before decoding a success payload."""
+    if response.status < 400:
+        return
+
+    detail = await response.text()
+    message = f"{response.status} error while {action} - {detail}"
+    if response.status in {401, 403}:
+        raise NotAuthenticatedException(message)
+    if response.status == 429 or response.status >= 500:
+        raise NestServiceException(message)
+    raise PynestException(message)
+
+
+async def _raise_for_google_status(response: ClientResponse, *, action: str) -> None:
+    """Classify Google token endpoint failures before JSON decoding."""
+    if response.status < 400:
+        return
+
+    if response.status == 429 or response.status >= 500:
+        raise NestServiceException(f"{response.status} error while {action}")
+
+    error = None
+    try:
+        payload = await response.json(content_type=None)
+        if isinstance(payload, dict):
+            error = payload.get("error")
+    except TypeError, ValueError:
+        pass
+
+    if _is_google_credential_error(error):
+        raise BadCredentialsException(str(error or response.status))
+    raise PynestException(f"{response.status} error while {action}")
+
+
+def _is_auth_error(error: Any) -> bool:
+    """Return whether an API error value explicitly describes rejection."""
+    if isinstance(error, str):
+        return error.lower() in _AUTH_ERROR_CODES
+    if isinstance(error, dict):
+        code = error.get("code") or error.get("status")
+        return isinstance(code, str) and code.lower() in _AUTH_ERROR_CODES
+    return False
+
+
+def _is_google_credential_error(error: Any) -> bool:
+    """Return whether Google explicitly rejected stored credentials."""
+    return isinstance(error, str) and error.lower() in _GOOGLE_CREDENTIAL_ERROR_CODES
+
+
+def _raise_for_nest_payload(payload: Any, *, action: str) -> None:
+    """Classify an API error carried inside a successful HTTP response."""
+    if not isinstance(payload, dict) or not (error := payload.get("error")):
+        return
+    if _is_auth_error(error):
+        raise NotAuthenticatedException(str(error))
+    raise PynestException(f"Nest error while {action}: {error}")
 
 
 def merge_cookies(original: str, new_cookies: dict[str, str]) -> str:
@@ -145,13 +217,16 @@ class NestClient:
                 "Content-Type": "application/x-www-form-urlencoded",
             },
         ) as response:
+            await _raise_for_google_status(
+                response, action="refreshing a Google access token"
+            )
             result = await response.json()
 
             if "error" in result:
-                if result["error"] == "invalid_grant":
+                if _is_google_credential_error(result["error"]):
                     raise BadCredentialsException(result["error"])
 
-                raise Exception(result["error"])
+                raise PynestException(result["error"])
 
             self.auth = GoogleAuthResponse(**result)
 
@@ -189,16 +264,18 @@ class NestClient:
                 self.refreshed_cookies = merge_cookies(cookies, new_cookies)
                 self.cookies = self.refreshed_cookies
 
+            await _raise_for_google_status(
+                response, action="refreshing a Google access token"
+            )
             result = await response.json()
 
             if "error" in result:
-                # Cookie method
-                if result["error"] == "USER_LOGGED_OUT":
+                if _is_google_credential_error(result["error"]):
                     raise BadCredentialsException(
-                        f"{result['error']} - {result['detail']}"
+                        f"{result['error']} - {result.get('detail', '')}"
                     )
 
-                raise Exception(result["error"])
+                raise PynestException(result["error"])
 
             self.auth = GoogleAuthResponseForCookies(**result)
 
@@ -223,7 +300,14 @@ class NestClient:
                 "Referer": self.environment.host,
             },
         ) as response:
+            await _raise_for_nest_status(
+                response, action="requesting a Nest session token"
+            )
             result = await response.json()
+            if error := result.get("error"):
+                if _is_auth_error(error):
+                    raise NotAuthenticatedException(str(error))
+                raise PynestException(str(error))
             nest_auth = NestAuthResponse(**result)
 
         async with self.session.get(
@@ -234,6 +318,7 @@ class NestClient:
                 + (nest_auth.jwt or ""),
             },
         ) as response:
+            await _raise_for_nest_status(response, action="authenticating")
             try:
                 nest_response = await response.json()
             except ContentTypeError as exception:
@@ -256,6 +341,8 @@ class NestClient:
             if nest_response.get("error"):
                 _LOGGER.error("Authentication error: %s", nest_response.get("error"))
 
+                if _is_auth_error(nest_response["error"]):
+                    raise NotAuthenticatedException(str(nest_response["error"]))
                 raise PynestException(
                     f"{response.status} error while authenticating - {nest_response}."
                 )
@@ -287,7 +374,15 @@ class NestClient:
                 "X-nl-protocol-version": str(1),
             },
         ) as response:
-            result = await response.json()
+            await _raise_for_nest_status(response, action="fetching initial data")
+            try:
+                result = await response.json()
+            except ContentTypeError as exception:
+                detail = await response.text()
+                raise PynestException(
+                    f"{response.status} invalid response while fetching initial data"
+                    f" - {detail}"
+                ) from exception
 
             if "2fa_enabled" in result:
                 result["_2fa_enabled"] = result.pop("2fa_enabled")
@@ -297,6 +392,8 @@ class NestClient:
                     "Received error from Nest service: %s", await response.text()
                 )
 
+                if _is_auth_error(result["error"]):
+                    raise NotAuthenticatedException(str(result["error"]))
                 raise PynestException(
                     f"{response.status} error while subscribing - {result}"
                 )
@@ -328,7 +425,6 @@ class NestClient:
                 }
             )
 
-        # TODO throw better exceptions
         async with self.session.post(
             f"{transport_url}/v6/subscribe",
             timeout=ClientTimeout(total=timeout),
@@ -345,14 +441,13 @@ class NestClient:
         ) as response:
             _LOGGER.debug("Data received via subscriber (status: %s)", response.status)
 
-            if response.status == 401:
-                raise NotAuthenticatedException(await response.text())
-
             if response.status == 504:
                 raise GatewayTimeoutException(await response.text())
 
             if response.status == 502:
                 raise BadGatewayException(await response.text())
+
+            await _raise_for_nest_status(response, action="subscribing for data")
 
             if response.status == 200 and response.content_type == "text/plain":
                 raise EmptyResponseException(await response.text())
@@ -366,7 +461,8 @@ class NestClient:
                     f"{response.status} error while subscribing - {result}"
                 ) from error
 
-            # TODO type object
+            _raise_for_nest_payload(result, action="subscribing for data")
+
             return result
 
     async def update_objects(
@@ -376,12 +472,11 @@ class NestClient:
         transport_url: str,
         objects_to_update: dict,
     ) -> Any:
-        """Subscribe for data."""
+        """Update Nest objects."""
 
         epoch = int(time.time())
         random = str(randint(100, 999))
 
-        # TODO throw better exceptions
         async with self.session.post(
             f"{transport_url}/v6/put",
             json={
@@ -394,8 +489,7 @@ class NestClient:
                 "X-nl-protocol-version": str(1),
             },
         ) as response:
-            if response.status == 401:
-                raise NotAuthenticatedException(await response.text())
+            await _raise_for_nest_status(response, action="updating objects")
 
             try:
                 result = await response.json()
@@ -403,9 +497,9 @@ class NestClient:
                 result = await response.text()
 
                 raise PynestException(
-                    f"{response.status} error while subscribing - {result}"
+                    f"{response.status} error while updating objects - {result}"
                 ) from err
 
-            # TODO type object
+            _raise_for_nest_payload(result, action="updating objects")
 
             return result

--- a/custom_components/nest_protect/pynest/grpc_client.py
+++ b/custom_components/nest_protect/pynest/grpc_client.py
@@ -30,6 +30,7 @@ from .protobuf_gen.weave.trait import security_pb2 as weave_security_pb2
 
 if TYPE_CHECKING:
     from .client import NestClient
+    from .models import NestResponse
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,6 +55,7 @@ _NO_LOCK_SETTLE_SECONDS = 30.0
 # HTTP statuses that mean the session token was rejected rather than that the
 # gateway had a transient problem. Retrying these forever never recovers.
 _AUTH_ERROR_STATUSES = frozenset({401, 403})
+_GRPC_UNAUTHENTICATED = 16
 
 # Protobuf wire-type for length-delimited fields. Every StreamBody field the
 # gateway sends is length-delimited (tag wire-type == 2); any other wire-type
@@ -241,9 +243,9 @@ class GrpcLockClient:
         # window. Set once and kept across reconnects.
         self._first_observe_at: float | None = None
 
-    def _headers(self) -> dict[str, str]:
+    def _headers(self, nest_session: NestResponse | None = None) -> dict[str, str]:
         """Build the protobuf headers using the current session token."""
-        session = self._nest_client.nest_session
+        session = nest_session or self._nest_client.nest_session
         if session is None or not session.access_token:
             raise NestLockAuthException("No active Nest session — cannot call gRPC-web")
         # NestEnvironment.host already carries the scheme ("https://home.nest.com"),
@@ -394,6 +396,11 @@ class GrpcLockClient:
                 continue
 
             if body.HasField("status") and body.status.code != 0:
+                if body.status.code == _GRPC_UNAUTHENTICATED:
+                    raise NestLockAuthException(
+                        "Observe stream rejected: "
+                        f"code={body.status.code} message={body.status.message!r}"
+                    )
                 _LOGGER.warning(
                     "Observe stream reported status code=%s message=%r",
                     body.status.code,
@@ -443,7 +450,9 @@ class GrpcLockClient:
             return
         self._locks_present = False
 
-    async def observe_locks(self) -> AsyncIterator[dict[str, LockState]]:
+    async def observe_locks(
+        self, *, nest_session: NestResponse | None = None
+    ) -> AsyncIterator[dict[str, LockState]]:
         """Long-lived observer. Yields `{resource_id: LockState}` per update batch.
 
         Reconnects on transient errors with exponential backoff. Ends the
@@ -457,7 +466,12 @@ class GrpcLockClient:
         delay = _RECONNECT_INITIAL_DELAY
         while True:
             try:
-                async for batch in self._observe_once():
+                stream = (
+                    self._observe_once()
+                    if nest_session is None
+                    else self._observe_once(nest_session=nest_session)
+                )
+                async for batch in stream:
                     delay = _RECONNECT_INITIAL_DELAY
                     yield batch
                 # Re-check on the way out too: a stream that ends right after
@@ -490,7 +504,9 @@ class GrpcLockClient:
                 await asyncio.sleep(delay)
                 delay = min(delay * 2, _RECONNECT_MAX_DELAY)
 
-    async def _observe_once(self) -> AsyncIterator[dict[str, LockState]]:
+    async def _observe_once(
+        self, *, nest_session: NestResponse | None = None
+    ) -> AsyncIterator[dict[str, LockState]]:
         """Single observe-stream session. Yields LockState batches until stream ends."""
         url = f"https://{self._grpc_host}{OBSERVE_ENDPOINT}"
         body = self._build_observe_request()
@@ -503,7 +519,7 @@ class GrpcLockClient:
         async with self._nest_client.session.post(
             url,
             data=body,
-            headers=self._headers(),
+            headers=self._headers(nest_session),
             timeout=ClientTimeout(
                 total=None, connect=_CONNECT_TIMEOUT, sock_read=_SOCK_READ_TIMEOUT
             ),
@@ -531,7 +547,13 @@ class GrpcLockClient:
                     )
                     return
 
-    async def send_lock_command(self, resource_id: str, lock: bool) -> None:
+    async def send_lock_command(
+        self,
+        resource_id: str,
+        lock: bool,
+        *,
+        nest_session: NestResponse | None = None,
+    ) -> None:
         """Send a lock or unlock command. Raises on failure."""
         state_value = (
             weave_security_pb2.BoltLockTrait.BoltState.BOLT_STATE_EXTENDED
@@ -559,7 +581,7 @@ class GrpcLockClient:
         async with self._nest_client.session.post(
             url,
             data=body,
-            headers=self._headers(),
+            headers=self._headers(nest_session),
             timeout=ClientTimeout(total=_SEND_COMMAND_TIMEOUT),
         ) as response:
             if response.status in _AUTH_ERROR_STATUSES:
@@ -581,6 +603,11 @@ class GrpcLockClient:
             resp.status.code,
             resp.status.message,
         )
+        if resp.status.code == _GRPC_UNAUTHENTICATED:
+            raise NestLockAuthException(
+                "Lock command rejected: "
+                f"code={resp.status.code} message={resp.status.message!r}"
+            )
         if resp.status.code != 0:
             raise NestLockCommandException(
                 f"Lock command rejected: code={resp.status.code} message={resp.status.message!r}"

--- a/custom_components/nest_protect/session.py
+++ b/custom_components/nest_protect/session.py
@@ -1,99 +1,343 @@
-"""Nest session manager with persistence and three-tier auth fallback."""
+"""Serialized Nest session lifecycle and credential recovery."""
 
 from __future__ import annotations
 
+import asyncio
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from aiohttp import ClientError
 from homeassistant.helpers.storage import Store
 
 from .const import (
-    BACKOFF_INTERVALS,
+    AUTH_RETRY_DELAYS,
+    CONF_AUTH_GENERATION,
+    CONF_PREVIOUS_AUTH_GENERATION,
     LOGGER,
-    MAX_AUTH_FAILURES,
     SESSION_EXPIRY_BUFFER_SECONDS,
 )
+from .credentials import (
+    CredentialProvider,
+    CredentialUpdateCallback,
+    apply_credential_updates,
+    create_credential_providers,
+    credential_field_names,
+)
 from .pynest.client import NestClient
-from .pynest.exceptions import NotAuthenticatedException, PynestException
+from .pynest.exceptions import (
+    BadCredentialsException,
+    NestServiceException,
+    NotAuthenticatedException,
+    PynestException,
+)
 from .pynest.models import FirstDataAPIResponse, NestResponse
+
+ReauthenticationCallback = Callable[[], None]
+_AUTH_SCOPED_STORE_FIELDS = frozenset(
+    {
+        CONF_AUTH_GENERATION,
+        CONF_PREVIOUS_AUTH_GENERATION,
+        "credentials",
+        "nest_session",
+        "transport_url",
+    }
+)
+
+
+def build_reauthentication_state(
+    current_state: Mapping[str, Any],
+    credential_generation: str,
+    previous_generation: str | None,
+    credentials: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build a handoff while preserving unrelated future Store metadata."""
+    state = {
+        key: value
+        for key, value in current_state.items()
+        if key not in _AUTH_SCOPED_STORE_FIELDS
+    }
+    state.update(
+        {
+            CONF_AUTH_GENERATION: credential_generation,
+            CONF_PREVIOUS_AUTH_GENERATION: previous_generation,
+            "credentials": dict(credentials),
+        }
+    )
+    return state
+
+
+@dataclass(frozen=True)
+class ProviderAuthenticationResult:
+    """A Nest session accepted by the complete provider pipeline."""
+
+    provider_name: str
+    session: NestResponse
+    data: FirstDataAPIResponse
+
+
+async def async_authenticate_with_providers_once(
+    client: NestClient,
+    providers: Sequence[CredentialProvider],
+) -> ProviderAuthenticationResult:
+    """Try one complete, validated authentication per available provider."""
+    last_bad_credentials: BadCredentialsException | None = None
+    last_session_rejection: NotAuthenticatedException | None = None
+    last_transient_failure: Exception | None = None
+
+    for provider in providers:
+        if not provider.available:
+            continue
+
+        LOGGER.debug("Authenticating with %s credentials", provider.name)
+        validated = False
+        try:
+            auth = await provider.async_get_access_token()
+            session = await client.authenticate(auth.access_token)
+            client.nest_session = session
+            data = await client.get_first_data(session.access_token, session.userid)
+        except BadCredentialsException as exception:
+            last_bad_credentials = exception
+        except NotAuthenticatedException as exception:
+            last_session_rejection = exception
+        except (
+            TimeoutError,
+            ClientError,
+            NestServiceException,
+            PynestException,
+        ) as exception:
+            last_transient_failure = exception
+        else:
+            validated = True
+            return ProviderAuthenticationResult(provider.name, session, data)
+        finally:
+            if not validated:
+                client.nest_session = None
+
+    if last_transient_failure is not None:
+        raise last_transient_failure
+    if last_session_rejection is not None:
+        raise last_session_rejection
+    if last_bad_credentials is not None:
+        raise last_bad_credentials
+    raise RuntimeError("No credential provider produced an authentication result")
 
 
 class NestSessionManager:
-    """Manage Nest session lifecycle: persist, restore, and authenticate.
-
-    Three-tier auth fallback on startup:
-    1. Reuse persisted Nest session if still valid (skip Google entirely)
-    2. Re-authenticate with Google using stored cookies/refresh_token
-    3. Return None (caller should raise ConfigEntryAuthFailed)
-    """
+    """Own Google credential exchange and the resulting Nest session."""
 
     def __init__(
         self,
         client: NestClient,
         store: Store,
+        *,
+        credential_generation: str | None = None,
+        credential_update_callback: CredentialUpdateCallback | None = None,
+        credential_providers: Sequence[CredentialProvider] | None = None,
+        initial_credentials: Mapping[str, Any] | None = None,
+        retry_delays: Sequence[float] = AUTH_RETRY_DELAYS,
     ) -> None:
         """Initialize the session manager."""
         self._client = client
         self._store = store
-        self._consecutive_failures: int = 0
+        self._credential_generation = credential_generation
+        self._credential_update_callback = credential_update_callback
+        self._retry_delays = tuple(retry_delays)
+        self._session_lock = asyncio.Lock()
+        self._stored_state: dict[str, Any] = {}
+        self._state_loaded = False
+        self._stored_credentials_applied = False
+        self._reauthentication_callback: ReauthenticationCallback | None = None
+        self._reauthentication_started = False
+        self._retired = False
+        self._credential_providers = tuple(
+            credential_providers
+            if credential_providers is not None
+            else create_credential_providers(client, self._async_save_credentials)
+        )
+        self._credential_fields = credential_field_names(self._credential_providers)
+        if initial_credentials:
+            apply_credential_updates(
+                self._client, initial_credentials, self._credential_fields
+            )
 
     @property
-    def refreshed_cookies(self) -> str | None:
-        """Proxy to client's refreshed_cookies property."""
-        return self._client.refreshed_cookies
+    def current_session(self) -> NestResponse | None:
+        """Return the active Nest session object."""
+        return self._client.nest_session
 
-    @property
-    def consecutive_failures(self) -> int:
-        """Return the number of consecutive failures."""
-        return self._consecutive_failures
+    def set_reauthentication_callback(self, callback: ReauthenticationCallback) -> None:
+        """Attach the runtime action for confirmed credential rejection."""
+        self._reauthentication_callback = callback
 
-    @property
-    def should_trigger_reauth(self) -> bool:
-        """Return True if failures exceed the threshold."""
-        return self._consecutive_failures >= MAX_AUTH_FAILURES
-
-    @property
-    def backoff_interval(self) -> int:
-        """Return the current backoff interval in seconds."""
-        if self._consecutive_failures == 0:
-            return BACKOFF_INTERVALS[0]
-        idx = min(self._consecutive_failures - 1, len(BACKOFF_INTERVALS) - 1)
-        return BACKOFF_INTERVALS[idx]
-
-    def record_failure(self) -> None:
-        """Record a consecutive failure."""
-        self._consecutive_failures += 1
-
-    def record_success(self) -> None:
-        """Reset failure counter on success."""
-        self._consecutive_failures = 0
+    def request_reauthentication(self) -> None:
+        """Request runtime reauthentication once."""
+        self._start_reauthentication()
 
     async def async_setup(self) -> FirstDataAPIResponse | None:
-        """Set up authentication using three-tier fallback.
+        """Restore a validated session or create one from configured providers."""
+        async with self._session_lock:
+            self._raise_if_retired()
+            await self._async_prepare_state()
 
-        Returns FirstDataAPIResponse on success, None if no credentials available.
-        """
-        nest_session = await self._async_try_persisted_session()
+            if data := await self._async_try_persisted_session():
+                return data
 
-        if nest_session is not None:
-            return nest_session
+            result = await self._async_authenticate_with_providers()
+            if result is None:
+                return None
 
-        return await self._async_authenticate_and_fetch()
+            _, data = result
+            return data
 
-    async def _async_try_persisted_session(self) -> FirstDataAPIResponse | None:
-        """Attempt to restore and validate a persisted session.
+    async def ensure_session(self) -> None:
+        """Ensure an unexpired Nest session exists."""
+        async with self._session_lock:
+            self._raise_if_retired()
+            if self._session_is_valid(self._client.nest_session):
+                return
 
-        Returns FirstDataAPIResponse if the session is valid and accepted, None otherwise.
-        """
-        persisted = await self._store.async_load()
+            await self._async_prepare_state()
+            await self._async_clear_persisted_session()
+            await self._async_refresh_session_locked()
 
-        if not persisted or not persisted.get("nest_session"):
+    async def async_refresh_session(
+        self, *, rejected_session: NestResponse | None = None
+    ) -> bool:
+        """Replace a rejected session, de-duplicating concurrent reports."""
+        async with self._session_lock:
+            self._raise_if_retired()
+            await self._async_prepare_state()
+            current = self._client.nest_session
+
+            if (
+                rejected_session is not None
+                and self._session_is_valid(current)
+                and current is not rejected_session
+            ):
+                return True
+
+            if rejected_session is not None:
+                self._client.auth = None
+            self._client.nest_session = None
+            await self._async_clear_persisted_session()
+            return await self._async_refresh_session_locked()
+
+    async def async_invalidate_session(self, *, rejected_session: NestResponse) -> None:
+        """Forget a replacement session rejected by its retrying consumer."""
+        async with self._session_lock:
+            self._raise_if_retired()
+            await self._async_prepare_state()
+            if self._client.nest_session is not rejected_session:
+                return
+
+            self._client.auth = None
+            self._client.nest_session = None
+            await self._async_clear_persisted_session()
+
+    async def async_stage_reauthentication(
+        self,
+        credential_generation: str,
+        credentials: Mapping[str, Any],
+    ) -> None:
+        """Retire this manager after durably staging replacement credentials."""
+        async with self._session_lock:
+            await self._async_load_state()
+            previous_generation = self._credential_generation
+            staged_state = build_reauthentication_state(
+                self._stored_state,
+                credential_generation,
+                previous_generation,
+                credentials,
+            )
+            await self._store.async_save(staged_state)
+
+            self._retired = True
+            self._credential_generation = credential_generation
+            self._client.auth = None
+            self._client.nest_session = None
+            self._stored_state = staged_state
+            self._state_loaded = True
+            self._stored_credentials_applied = True
+
+    async def _async_refresh_session_locked(self) -> bool:
+        """Refresh the Nest session while holding the session lock."""
+        auth = self._client.auth
+        if auth and not auth.is_expired():
+            validated = False
+            try:
+                session = await self._client.authenticate(auth.access_token)
+                await self._client.get_first_data(session.access_token, session.userid)
+            except NotAuthenticatedException:
+                self._client.auth = None
+            else:
+                validated = True
+                self._client.nest_session = session
+                await self._async_persist_session(session)
+                return True
+            finally:
+                if not validated:
+                    self._client.nest_session = None
+
+        result = await self._async_authenticate_with_providers()
+        if result is None:
+            self._start_reauthentication()
+            raise BadCredentialsException("No credentials available")
+        return True
+
+    async def _async_authenticate_with_providers(
+        self,
+    ) -> tuple[NestResponse, FirstDataAPIResponse] | None:
+        """Try every provider, retrying only explicit authentication rejection."""
+        if not any(provider.available for provider in self._credential_providers):
             return None
 
-        restored_session = NestResponse.from_dict(persisted["nest_session"])
+        last_bad_credentials: BadCredentialsException | None = None
+        last_session_rejection: NotAuthenticatedException | None = None
 
-        if restored_session is None:
+        for attempt in range(len(self._retry_delays) + 1):
+            try:
+                result = await async_authenticate_with_providers_once(
+                    self._client, self._credential_providers
+                )
+            except BadCredentialsException as exception:
+                last_bad_credentials = exception
+            except NotAuthenticatedException as exception:
+                last_session_rejection = exception
+            else:
+                await self._async_persist_session(result.session)
+                return result.session, result.data
+
+            if attempt < len(self._retry_delays):
+                delay = self._retry_delays[attempt]
+                LOGGER.debug(
+                    "Authentication attempt %d rejected; retrying in %ss",
+                    attempt + 1,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+
+        if last_session_rejection is not None:
+            raise last_session_rejection
+
+        if last_bad_credentials is None:
+            raise RuntimeError("Authentication attempts ended without a result")
+
+        self._start_reauthentication()
+        raise last_bad_credentials
+
+    async def _async_try_persisted_session(
+        self,
+    ) -> FirstDataAPIResponse | None:
+        """Validate a non-expired session from durable state."""
+        persisted_session = self._stored_state.get("nest_session")
+        if not persisted_session:
             return None
 
-        if restored_session.is_expired(buffer_seconds=SESSION_EXPIRY_BUFFER_SECONDS):
-            LOGGER.debug("Persisted session expired, falling through to cookie auth")
+        restored_session = NestResponse.from_dict(persisted_session)
+        if restored_session is None or not self._session_is_valid(restored_session):
+            await self._async_clear_persisted_session()
             return None
 
         LOGGER.debug(
@@ -101,88 +345,157 @@ class NestSessionManager:
             restored_session.expires_in,
         )
         self._client.nest_session = restored_session
-        self._client.transport_url = persisted.get("transport_url")
+        self._client.transport_url = self._stored_state.get("transport_url")
 
-        # Validate the session is actually accepted by Nest
+        validated = False
         try:
-            return await self._client.get_first_data(
+            data = await self._client.get_first_data(
                 restored_session.access_token, restored_session.userid
             )
-        except (NotAuthenticatedException, PynestException):  # fmt: skip
+        except NotAuthenticatedException:
             LOGGER.debug(
-                "Persisted session rejected by Nest, falling through to cookie auth"
+                "Persisted session rejected by Nest, falling through to credentials"
             )
-            self._client.nest_session = None
+            await self._async_clear_persisted_session()
             return None
-
-    async def _async_authenticate_and_fetch(self) -> FirstDataAPIResponse | None:
-        """Authenticate with credentials and fetch first data.
-
-        Returns FirstDataAPIResponse on success, None if no credentials available.
-        """
-        nest_response = await self._async_authenticate_with_credentials()
-
-        if nest_response is None:
-            return None
-
-        self._client.nest_session = nest_response
-        await self._async_persist(nest_response)
-
-        return await self._client.get_first_data(
-            nest_response.access_token, nest_response.userid
-        )
-
-    async def _async_authenticate_with_credentials(self) -> NestResponse | None:
-        """Authenticate using cookies or refresh_token.
-
-        Returns a NestResponse on success, None if no credentials are available.
-        Raises authentication exceptions from the underlying client on failure.
-        """
-        if self._client.issue_token and self._client.cookies:
-            auth = await self._client.get_access_token_from_cookies(
-                self._client.issue_token, self._client.cookies
-            )
-        elif self._client.refresh_token:
-            auth = await self._client.get_access_token_from_refresh_token(
-                self._client.refresh_token
-            )
         else:
-            return None
+            validated = True
+            return data
+        finally:
+            if not validated:
+                self._client.nest_session = None
 
-        return await self._client.authenticate(auth.access_token)
-
-    async def ensure_session(self) -> None:
-        """Ensure a valid Nest session exists, refreshing if needed."""
-        if self._client.nest_session and not self._client.nest_session.is_expired(
-            buffer_seconds=SESSION_EXPIRY_BUFFER_SECONDS
-        ):
+    async def _async_prepare_state(self) -> None:
+        """Load durable state and apply newer stored credentials once."""
+        await self._async_load_state()
+        await self._async_prepare_credential_generation()
+        if self._stored_credentials_applied:
             return
 
-        await self.async_refresh_session()
+        self._stored_credentials_applied = True
+        updates = self._stored_state.get("credentials")
+        if not isinstance(updates, dict) or not updates:
+            return
 
-    async def async_refresh_session(self) -> bool:
-        """Force-refresh the Nest session via Google credentials.
+        apply_credential_updates(self._client, updates, self._credential_fields)
+        if self._credential_update_callback:
+            await self._credential_update_callback(
+                self._with_credential_generation(updates)
+            )
 
-        Returns True when a fresh Nest session was obtained and persisted.
-        """
-        if not self._client.auth or self._client.auth.is_expired():
-            LOGGER.debug("Retrieving new Google access token")
-            await self._client.get_access_token()
+    async def _async_prepare_credential_generation(self) -> None:
+        """Reconcile durable state with the config entry's login generation."""
+        stored_generation = self._stored_state.get(CONF_AUTH_GENERATION)
+        previous_generation_present = (
+            CONF_PREVIOUS_AUTH_GENERATION in self._stored_state
+        )
+        previous_generation = self._stored_state.get(CONF_PREVIOUS_AUTH_GENERATION)
 
-        if not self._client.auth:
+        if self._credential_generation is None:
+            self._credential_generation = stored_generation or uuid.uuid4().hex
+            if stored_generation is None:
+                self._stored_state[CONF_AUTH_GENERATION] = self._credential_generation
+                await self._store.async_save(self._stored_state)
+
+            if self._credential_update_callback:
+                await self._credential_update_callback(
+                    {CONF_AUTH_GENERATION: self._credential_generation}
+                )
+            return
+
+        if stored_generation == self._credential_generation:
+            return
+
+        if (
+            previous_generation_present
+            and previous_generation == self._credential_generation
+            and isinstance(stored_generation, str)
+        ):
+            self._credential_generation = stored_generation
+            if self._credential_update_callback:
+                await self._credential_update_callback(
+                    {
+                        CONF_AUTH_GENERATION: stored_generation,
+                        CONF_PREVIOUS_AUTH_GENERATION: previous_generation,
+                    }
+                )
+            return
+
+        self._stored_state = {
+            key: value
+            for key, value in self._stored_state.items()
+            if key not in _AUTH_SCOPED_STORE_FIELDS
+        }
+        self._stored_state[CONF_AUTH_GENERATION] = self._credential_generation
+        await self._store.async_save(self._stored_state)
+
+    async def _async_load_state(self) -> None:
+        """Load the Store once."""
+        if self._state_loaded:
+            return
+
+        stored = await self._store.async_load()
+        self._stored_state = dict(stored) if stored else {}
+        self._state_loaded = True
+
+    async def _async_save_credentials(self, updates: Mapping[str, Any]) -> None:
+        """Durably save provider changes before dependent requests continue."""
+        await self._async_load_state()
+        credentials = dict(self._stored_state.get("credentials", {}))
+        changed = any(
+            key not in credentials or credentials[key] != value
+            for key, value in updates.items()
+        )
+        if not changed:
+            return
+
+        credentials.update(updates)
+        self._stored_state["credentials"] = credentials
+        await self._store.async_save(self._stored_state)
+        apply_credential_updates(self._client, updates, self._credential_fields)
+
+        if self._credential_update_callback:
+            await self._credential_update_callback(
+                self._with_credential_generation(updates)
+            )
+
+    async def _async_persist_session(self, session: NestResponse) -> None:
+        """Persist a usable Nest session without dropping credential state."""
+        self._stored_state["nest_session"] = session.to_dict()
+        self._stored_state["transport_url"] = self._client.transport_url
+        await self._store.async_save(self._stored_state)
+
+    async def _async_clear_persisted_session(self) -> None:
+        """Remove a rejected or expired Nest session from durable state."""
+        removed = self._stored_state.pop("nest_session", None) is not None
+        removed = self._stored_state.pop("transport_url", None) is not None or removed
+        if removed:
+            await self._store.async_save(self._stored_state)
+
+    def _start_reauthentication(self) -> None:
+        """Start runtime reauthentication at most once."""
+        if self._reauthentication_started or not self._reauthentication_callback:
+            return
+        self._reauthentication_started = True
+        self._reauthentication_callback()
+
+    def _with_credential_generation(self, updates: Mapping[str, Any]) -> dict[str, Any]:
+        """Tag config-entry updates so a replaced manager cannot overwrite them."""
+        if self._credential_generation is None:
+            raise RuntimeError("Credential generation has not been prepared")
+        return {**updates, CONF_AUTH_GENERATION: self._credential_generation}
+
+    def _raise_if_retired(self) -> None:
+        """Prevent a manager replaced by reauthentication from writing again."""
+        if self._retired:
+            raise NotAuthenticatedException("Authentication generation was replaced")
+
+    @staticmethod
+    def _session_is_valid(session: NestResponse | None) -> bool:
+        """Return whether a session is present outside its expiry buffer."""
+        if session is None:
             return False
-
-        self._client.nest_session = await self._client.authenticate(
-            self._client.auth.access_token
-        )
-        await self._async_persist(self._client.nest_session)
-        return True
-
-    async def _async_persist(self, nest_session: NestResponse) -> None:
-        """Save Nest session to store for reuse across restarts."""
-        await self._store.async_save(
-            {
-                "nest_session": nest_session.to_dict(),
-                "transport_url": self._client.transport_url,
-            }
-        )
+        try:
+            return not session.is_expired(buffer_seconds=SESSION_EXPIRY_BUFFER_SECONDS)
+        except TypeError, ValueError:
+            return False

--- a/docs/superpowers/plans/2026-07-29-auth-session-coordinator.md
+++ b/docs/superpowers/plans/2026-07-29-auth-session-coordinator.md
@@ -1,0 +1,470 @@
+# Authentication Session Coordinator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build one extensible, serialized authentication coordinator that
+durably saves credential rotations before downstream Nest calls and only starts
+reauthentication after repeated explicit credential rejection.
+
+**Architecture:** Credential-specific Google token acquisition moves behind a
+small provider protocol in `credentials.py`. `NestSessionManager` owns provider
+fallback, bounded rejection retries, single-flight Nest-session refresh, and a
+merged durable state record. Runtime callers only request or recover a Nest
+session.
+
+**Tech Stack:** Python 3.14, asyncio, aiohttp, Home Assistant config entries and
+Store, pytest, pytest-asyncio, Ruff.
+
+## Global Constraints
+
+- Preserve cookie and legacy refresh-token authentication.
+- New authentication methods require a provider registration, not edits to
+  every runtime consumer.
+- Persist provider credential changes before any dependent Nest request.
+- Serialize all Google-token and Nest-session changes.
+- Never start reauthentication for network, 429, 5xx, or malformed responses.
+- Tag durable auth state with a login generation so reauth cannot restore a
+  late write from the manager being replaced.
+- Do not log credential values.
+- Keep provider logic in `credentials.py`, session policy in `session.py`, and
+  domain operations at their existing call sites.
+- Execute every command through the devcontainer CLI.
+
+---
+
+### Task 1: Credential provider boundary
+
+**Files:**
+- Create: `custom_components/nest_protect/credentials.py`
+- Create: `tests/test_credentials.py`
+- Modify: `custom_components/nest_protect/const.py`
+
+**Interfaces:**
+- Produces: `CredentialProvider`, `CredentialUpdateCallback`,
+  `CookieCredentialProvider`, `RefreshTokenCredentialProvider`, and
+  `create_credential_providers(client, async_save_credentials)`.
+- Consumes: existing `NestClient` cookie and refresh-token methods.
+
+- [ ] **Step 1: Write failing provider behavior tests**
+
+```python
+async def test_cookie_provider_saves_rotation_when_request_is_rejected():
+    client = MagicMock(cookies="SID=old", refreshed_cookies=None)
+
+    async def reject(*_):
+        client.cookies = "SID=new"
+        client.refreshed_cookies = "SID=new"
+        raise BadCredentialsException("USER_LOGGED_OUT")
+
+    client.get_access_token_from_cookies = AsyncMock(side_effect=reject)
+    saved = AsyncMock()
+    provider = CookieCredentialProvider(client, saved)
+
+    with pytest.raises(BadCredentialsException):
+        await provider.async_get_access_token()
+
+    assert saved.await_args.args[0] == {CONF_COOKIES: "SID=new"}
+
+
+async def test_refresh_token_provider_remains_supported():
+    client = MagicMock(refresh_token="legacy-token")
+    client.get_access_token_from_refresh_token = AsyncMock(
+        return_value=MagicMock(access_token="google-token")
+    )
+
+    provider = RefreshTokenCredentialProvider(client, AsyncMock())
+
+    assert (await provider.async_get_access_token()).access_token == "google-token"
+```
+
+- [ ] **Step 2: Verify the tests fail because the module is absent**
+
+Run:
+
+```bash
+devcontainer exec --workspace-folder /Users/mick/Projects/ha-nest-protect \
+  sh -lc 'cd /workspaces/ha-nest-protect/config/codex-worktrees/auth-session-coordinator && /tmp/ha-nest-protect-maint-baseline/.venv-auth-investigation/bin/pytest -q tests/test_credentials.py'
+```
+
+Expected: collection fails because `credentials.py` does not exist.
+
+- [ ] **Step 3: Implement the provider protocol and providers**
+
+```python
+CredentialUpdateCallback = Callable[[Mapping[str, Any]], Awaitable[None]]
+
+
+class CredentialProvider(Protocol):
+    name: str
+
+    @property
+    def available(self) -> bool: ...
+
+    async def async_get_access_token(self) -> GoogleAuthResponse: ...
+
+
+class CookieCredentialProvider:
+    name = "cookies"
+
+    async def async_get_access_token(self) -> GoogleAuthResponse:
+        previous = self._client.cookies
+        try:
+            return await self._client.get_access_token_from_cookies(
+                self._client.issue_token, previous
+            )
+        finally:
+            refreshed = self._client.refreshed_cookies
+            if refreshed and refreshed != previous:
+                await self._async_save_credentials({CONF_COOKIES: refreshed})
+```
+
+Implement the refresh-token provider and factory with cookie-first ordering.
+Add `AUTH_RETRY_DELAYS = (1, 5)` to `const.py`.
+
+- [ ] **Step 4: Run provider tests and Ruff**
+
+Run the focused pytest command from Step 2, followed by:
+
+```bash
+devcontainer exec --workspace-folder /Users/mick/Projects/ha-nest-protect \
+  sh -lc 'cd /workspaces/ha-nest-protect/config/codex-worktrees/auth-session-coordinator && /tmp/ha-nest-protect-maint-baseline/.venv-auth-investigation/bin/ruff check custom_components/nest_protect/credentials.py tests/test_credentials.py'
+```
+
+Expected: all provider tests pass and Ruff exits zero.
+
+### Task 2: Durable, single-flight session orchestration
+
+**Files:**
+- Modify: `custom_components/nest_protect/session.py`
+- Modify: `tests/test_session.py`
+
+**Interfaces:**
+- Consumes: `CredentialProvider` and `create_credential_providers` from Task 1.
+- Produces:
+  `NestSessionManager(..., credential_update_callback=None, retry_delays=...)`,
+  `ensure_session()`, and
+  `async_refresh_session(rejected_session: NestResponse | None = None)`.
+
+- [ ] **Step 1: Add failing durable-ordering and restart tests**
+
+Use a small `MemoryStore` that copies values on save/load. Exercise the real
+cookie provider and session manager while mocking only network operations.
+
+```python
+async def test_rotation_survives_nest_failure_and_restart():
+    first_client = make_cookie_client("SID=old")
+
+    async def rotate(*_):
+        first_client.cookies = "SID=new"
+        first_client.refreshed_cookies = "SID=new"
+        return MagicMock(access_token="google-token")
+
+    first_client.get_access_token_from_cookies.side_effect = rotate
+    first_client.authenticate.side_effect = PynestException("Nest unavailable")
+    store = MemoryStore()
+    manager = NestSessionManager(first_client, store, retry_delays=())
+
+    with pytest.raises(PynestException):
+        await manager.async_setup()
+
+    restarted_client = make_cookie_client("SID=old")
+    restarted_manager = NestSessionManager(restarted_client, store, retry_delays=())
+    restarted_client.authenticate.side_effect = PynestException("stop")
+
+    with pytest.raises(PynestException):
+        await restarted_manager.async_setup()
+
+    assert (
+        restarted_client.get_access_token_from_cookies.await_args.args[1] == "SID=new"
+    )
+```
+
+Also add tests proving:
+
+- a transient persisted-session failure does not invoke providers;
+- cookie rejection falls back to refresh-token authentication;
+- all providers must explicitly reject on every bounded attempt before
+  `BadCredentialsException` is raised;
+- concurrent `ensure_session()` calls perform one refresh;
+- two callers reporting the same rejected Nest session perform one refresh;
+- a stored credential update is applied before persisted-session validation.
+
+- [ ] **Step 2: Run each new test and confirm the expected current failure**
+
+Run each test by node ID. Expected failures must identify missing durable
+credentials, missing locking, or missing provider fallback rather than fixture
+errors.
+
+- [ ] **Step 3: Implement merged durable state**
+
+Load the Store once into `_stored_state`. Preserve unknown keys. Save credential
+updates under `credentials`, and await the Store write before invoking the
+config-entry callback.
+
+```python
+async def _async_save_credentials(self, updates: Mapping[str, Any]) -> None:
+    await self._async_load_state()
+    credentials = dict(self._stored_state.get("credentials", {}))
+    credentials.update(updates)
+    self._stored_state["credentials"] = credentials
+    await self._store.async_save(self._stored_state)
+    apply_credential_updates(self._client, updates)
+    if self._credential_update_callback:
+        await self._credential_update_callback(updates)
+```
+
+- [ ] **Step 4: Implement serialization, provider fallback, and rejection retry**
+
+Guard setup and refresh with one `asyncio.Lock`. Re-check session state inside
+the lock. Try an unexpired cached Google token once, then each provider.
+Continue to the next provider only for explicit credential or Nest-token
+rejection. Retry a complete all-provider rejection using `retry_delays`.
+
+Invoke the optional reauthentication callback only when every attempt ended in
+explicit provider rejection.
+
+- [ ] **Step 5: Narrow persisted-session fallback**
+
+Only `NotAuthenticatedException` invalidates a restored session and falls back
+to credentials. Transient and malformed Nest responses propagate without
+touching credentials.
+
+- [ ] **Step 6: Run the full session test file and Ruff**
+
+Expected: all session tests pass; old call-site failure-counter tests will be
+removed in Task 5 when the callers migrate.
+
+- [ ] **Step 7: Protect reauthentication from stale Store writes**
+
+Persist an opaque authentication generation before the first external request.
+Adopt a durable generation when an upgraded config entry has not mirrored it
+yet. When the config entry and Store generations differ, keep the config-entry
+generation and discard all older durable credentials and sessions. For manual
+reauthentication, write a predecessor-linked handoff before the delayed
+config-entry update and retire the old manager under its session lock.
+
+### Task 3: HTTP authentication error classification
+
+**Files:**
+- Modify: `custom_components/nest_protect/pynest/client.py`
+- Modify: `custom_components/nest_protect/pynest/exceptions.py`
+- Modify: `tests/pynest/test_client.py`
+
+**Interfaces:**
+- Produces consistent `NotAuthenticatedException`,
+  `NestServiceException`, `BadCredentialsException`, and `PynestException`
+  outcomes from Google-token, Nest-session, and app-launch endpoints.
+
+- [ ] **Step 1: Add failing response classification tests**
+
+Use the existing aiohttp test server to cover JSON and text responses:
+
+```python
+@pytest.mark.parametrize("status", [401, 403])
+async def test_get_first_data_classifies_auth_status(status, socket_enabled):
+    ...
+    with pytest.raises(NotAuthenticatedException):
+        await client.get_first_data("token", "user")
+
+
+@pytest.mark.parametrize("status", [429, 500, 503])
+async def test_get_first_data_classifies_transient_status(status, socket_enabled):
+    ...
+    with pytest.raises(NestServiceException):
+        await client.get_first_data("token", "user")
+```
+
+Add equivalent coverage for `/session`, and confirm unknown Google errors raise
+`PynestException` rather than a bare `Exception`.
+
+- [ ] **Step 2: Run the new tests and verify their current exception mismatch**
+
+Expected: tests fail with `ContentTypeError`, `PynestException`, or a bare
+`Exception`.
+
+- [ ] **Step 3: Add one response-status helper and use it before success decoding**
+
+```python
+async def _raise_for_nest_status(response: ClientResponse, action: str) -> None:
+    if response.status in {401, 403}:
+        raise NotAuthenticatedException(await response.text())
+    if response.status == 429 or response.status >= 500:
+        raise NestServiceException(
+            f"{response.status} error while {action} - {await response.text()}"
+        )
+```
+
+Keep explicit Google `USER_LOGGED_OUT` and `invalid_grant` mapping to
+`BadCredentialsException`; map other error payloads to `PynestException`.
+
+- [ ] **Step 4: Run client tests and Ruff**
+
+Expected: all client tests pass and error payloads contain no credentials.
+
+### Task 4: Home Assistant persistence and configuration integration
+
+**Files:**
+- Modify: `custom_components/nest_protect/__init__.py`
+- Modify: `custom_components/nest_protect/config_flow.py`
+- Modify: `tests/test_init.py`
+- Modify: `tests/test_config_flow.py`
+
+**Interfaces:**
+- Consumes: manager credential callback and provider factory.
+- Produces: config-entry mirroring, reauth callback registration, config-flow
+  provider validation, and removal of stale Store state after manual reauth.
+
+- [ ] **Step 1: Add failing setup persistence tests**
+
+Cover a rotation followed by Nest failure and assert the per-entry Store
+contains the new cookie even though the config entry remains in setup retry.
+Then create a fresh setup with the same Store and assert it sends the new
+cookie.
+
+- [ ] **Step 2: Add failing config-flow tests**
+
+Assert refresh-token validation still succeeds through the provider factory,
+cookie rotations are returned, and a downstream Nest failure reuses a captured
+rotation on the next form attempt. Assign a fresh authentication generation,
+stage the credentials durably before config-entry mutation, and fence every
+late callback from the replaced manager.
+
+- [ ] **Step 3: Wire the manager callback**
+
+Create an async callback in `async_setup_entry` that updates the live client and
+config entry. Pass it to `NestSessionManager`. Remove
+`_persist_refreshed_cookies` and every caller of it.
+
+After successful setup, attach:
+
+```python
+session_manager.set_reauthentication_callback(lambda: entry.async_start_reauth(hass))
+```
+
+- [ ] **Step 4: Use providers in config-flow validation**
+
+Initialize the client from submitted credentials, select the first available
+provider, capture updates in a local mapping, and validate the Nest session.
+Retain rotations across form retries. Stage successful reauth data and its new
+generation in Store before updating the config entry.
+
+- [ ] **Step 5: Run init/config-flow tests and Ruff**
+
+Expected: both cookie and refresh-token fixtures load, rotated data is durable,
+and no old post-Nest-call cookie copy remains.
+
+### Task 5: Migrate every runtime consumer
+
+**Files:**
+- Modify: `custom_components/nest_protect/__init__.py`
+- Modify: `custom_components/nest_protect/diagnostics.py`
+- Modify: `custom_components/nest_protect/entity.py`
+- Modify: `custom_components/nest_protect/lock.py`
+- Modify: affected tests under `tests/`
+- Create: `tests/test_diagnostics.py` if diagnostics has no existing test file.
+
+**Interfaces:**
+- Consumes: `ensure_session()` and
+  `async_refresh_session(rejected_session=...)`.
+- Produces: no direct runtime calls to Google token methods outside the
+  credential providers.
+
+- [ ] **Step 1: Add failing consumer tests**
+
+Assert:
+
+- diagnostics calls `ensure_session` and never calls Google token methods;
+- an updatable entity retries once after `NotAuthenticatedException`;
+- a lock command ensures a session and retries once after
+  `NestLockAuthException`;
+- subscriber and lock observer pass the exact rejected session object;
+- two consumer failures for the same token cause one provider refresh;
+- transient refresh failure schedules recovery without starting reauth;
+- exhausted explicit credential rejection starts reauth once.
+
+- [ ] **Step 2: Run each focused test and verify current behavior fails**
+
+Expected: direct-auth diagnostics, missing command retry, old shared counters, or
+duplicate refresh calls cause the failures.
+
+- [ ] **Step 3: Migrate diagnostics and entity operations**
+
+Diagnostics uses the existing Nest session after `ensure_session`.
+`NestUpdatableEntity` retries the domain request once after coordinated
+recovery.
+
+- [ ] **Step 4: Migrate subscriber and lock observer**
+
+Capture the Nest access token used by each operation. On a 401/403, ask the
+manager to replace that token. Remove per-call-site auth failure counters and
+cookie persistence.
+
+- [ ] **Step 5: Migrate lock commands**
+
+Pass `NestSessionManager` to `NestLockEntity`, ensure the session before a
+command, and retry one time after coordinated recovery. Preserve existing
+`HomeAssistantError` behavior for final failure.
+
+- [ ] **Step 6: Prove no runtime auth bypass remains**
+
+Run:
+
+```bash
+devcontainer exec --workspace-folder /Users/mick/Projects/ha-nest-protect \
+  sh -lc 'cd /workspaces/ha-nest-protect/config/codex-worktrees/auth-session-coordinator && git grep -n "get_access_token_from_cookies\\|get_access_token_from_refresh_token" -- custom_components/nest_protect'
+```
+
+Expected matches: credential providers, config-flow setup code if needed, and
+low-level client definitions only.
+
+- [ ] **Step 7: Run all consumer tests and Ruff**
+
+Expected: focused tests pass without credential-value logging or sleeps longer
+than the injected retry policy.
+
+### Task 6: Full verification and readability review
+
+**Files:**
+- Modify only files needed to correct verification findings.
+
+**Interfaces:**
+- Consumes: all earlier tasks.
+- Produces: releasable branch evidence.
+
+- [ ] **Step 1: Run formatter and lint**
+
+```bash
+devcontainer exec --workspace-folder /Users/mick/Projects/ha-nest-protect \
+  sh -lc 'cd /workspaces/ha-nest-protect/config/codex-worktrees/auth-session-coordinator && /tmp/ha-nest-protect-maint-baseline/.venv-auth-investigation/bin/ruff format --check . && /tmp/ha-nest-protect-maint-baseline/.venv-auth-investigation/bin/ruff check .'
+```
+
+- [ ] **Step 2: Run the complete test suite**
+
+```bash
+devcontainer exec --workspace-folder /Users/mick/Projects/ha-nest-protect \
+  sh -lc 'cd /workspaces/ha-nest-protect/config/codex-worktrees/auth-session-coordinator && /tmp/ha-nest-protect-maint-baseline/.venv-auth-investigation/bin/pytest -q'
+```
+
+- [ ] **Step 3: Run restart, rejection, and concurrency regression tests alone**
+
+Run the named tests from Tasks 2, 4, and 5 with `-vv` so their individual
+results are visible.
+
+- [ ] **Step 4: Review the final diff**
+
+Check that:
+
+- `session.py` is the only runtime authentication policy owner;
+- credential providers do not import Home Assistant objects;
+- every credential update is saved before Nest authentication;
+- token-only entries have explicit test coverage;
+- transient exceptions cannot call `async_start_reauth`;
+- no credential values appear in logs or test failure output;
+- comments explain only non-obvious ordering and compatibility constraints.
+
+- [ ] **Step 5: Run `git diff --check` and report exact verification counts**
+
+Do not claim completion unless every fresh command exits zero.

--- a/docs/superpowers/specs/2026-07-29-auth-session-coordinator-design.md
+++ b/docs/superpowers/specs/2026-07-29-auth-session-coordinator-design.md
@@ -1,0 +1,321 @@
+# Authentication Session Coordinator Design
+
+## Goal
+
+Make authentication recovery deterministic across Home Assistant restarts,
+concurrent consumers, transient service failures, and credential rotation while
+keeping cookie, refresh-token, and future authentication methods isolated and
+readable.
+
+The integration can eliminate false reauthentication and lost credential
+updates. It cannot make credentials valid after Google revokes them or binds
+them to another device, so a confirmed rejection still ends in Home Assistant's
+reauthentication flow.
+
+## Problems Being Solved
+
+The current implementation splits ownership across layers:
+
+- `NestClient` receives and applies rotated Google cookies in memory.
+- `NestSessionManager` creates and stores Nest sessions.
+- setup, subscriber, and lock call sites sometimes copy rotated cookies into
+  the config entry after unrelated Nest calls complete.
+- diagnostics performs its own authentication and does not persist rotations.
+- entity and lock operations can race the subscriber for the same mutable
+  client state.
+
+This leaves several reproducible failure windows:
+
+1. Google rotates cookies, a subsequent Nest call fails, and Home Assistant
+   restarts before the caller persists the new cookies.
+2. Two consumers refresh concurrently and overwrite or repeat the same work.
+3. Subscriber and lock failures from one rejected session are counted as
+   independent credential failures.
+4. A transient Nest response is interpreted as credential rejection.
+5. Runtime paths bypass the persistence behavior added to other call sites.
+
+## Approaches Considered
+
+### Patch every call site
+
+Each caller would continue authenticating directly and would persist cookies in
+a `finally` block. This is a small diff, but every new feature would need to
+repeat locking, persistence, fallback, retry, and classification correctly.
+This is the pattern that created the current gaps, so it is rejected.
+
+### Put Home Assistant persistence inside `NestClient`
+
+The low-level client could save credentials whenever an HTTP response rotates
+them. This closes the timing window but couples the reusable protocol client to
+Home Assistant config entries and storage. It also makes config-flow validation
+and testing harder. This is rejected.
+
+### Provider-based session coordinator
+
+Credential providers acquire Google access tokens and report provider-specific
+durable changes. `NestSessionManager` owns serialization, retry and fallback,
+Nest-session persistence, and the ordering of durable writes. Home Assistant
+supplies a small callback that mirrors durable credential updates into the
+config entry. This is the selected design.
+
+## Components
+
+### Credential providers
+
+A `CredentialProvider` protocol exposes:
+
+- a human-readable provider name for safe logging;
+- the config-entry fields owned by that provider;
+- whether its required credentials are available;
+- an async method that returns a Google access token.
+
+Providers receive a callback for credential updates. A provider invokes that
+callback before returning or re-raising, so response-side rotations are not
+lost when a later step fails.
+
+Initial implementations:
+
+- `CookieCredentialProvider` uses `issue_token` and cookies. It durably saves
+  any cookie rotation observed by `NestClient`, including rotations returned
+  alongside a rejected response.
+- `RefreshTokenCredentialProvider` uses the legacy refresh token and produces
+  no update today. The interface permits future refresh-token rotation.
+
+The provider factory preserves the existing preference for cookie credentials
+when both methods are present, then falls back to the refresh token. Runtime
+and config-flow validation call the same complete provider-pipeline helper.
+Adding a future method requires a provider and one factory registration rather
+than changes in every authentication consumer. Provider-declared fields also
+drive client hydration, durable replay, credential retirement, and config-flow
+pending-state identity.
+
+### Nest session manager
+
+`NestSessionManager` becomes the only runtime authentication coordinator. It
+owns:
+
+- one `asyncio.Lock` covering all Google-token and Nest-session changes;
+- the ordered credential providers;
+- a cached Google access token fast path;
+- persisted Nest session validation;
+- durable credential and Nest-session state;
+- bounded credential rejection retries;
+- de-duplication when multiple consumers report the same rejected session
+  object, even if Nest issues the same token value again;
+- one optional runtime callback that starts reauthentication after confirmed
+  credential rejection.
+
+Public operations remain small:
+
+- `async_setup()` restores credentials and a Nest session, or creates and
+  validates a new session.
+- `ensure_session()` returns an unexpired session, refreshing under the lock
+  when necessary.
+- `async_refresh_session(rejected_session=...)` replaces a rejected session. If
+  another consumer already replaced that exact session object, it reuses the
+  new session instead of refreshing again.
+- `async_invalidate_session(rejected_session=...)` removes a replacement that
+  the retrying consumer also rejects, so it cannot become a bad persisted fast
+  path on the next restart.
+- `set_reauthentication_callback()` attaches Home Assistant behavior only
+  after setup succeeds.
+
+### Durable state
+
+The existing per-entry `Store` remains the durable session record and gains a
+generic `credentials` mapping plus an opaque authentication-generation marker.
+When a provider reports an update, the manager:
+
+1. updates its in-memory stored state;
+2. awaits `Store.async_save`;
+3. applies the update to the live client;
+4. mirrors it to the config entry through the callback;
+5. only then proceeds to Nest authentication.
+
+The Store write closes the one-second delayed config-entry-save crash window.
+On startup, stored credential updates are applied before any authentication
+attempt. The generation marker handles both sides of the remaining race:
+
+- an upgraded entry without a marker adopts the durable marker, so a crash
+  between Store and config-entry writes does not discard a valid rotation;
+- successful manual reauthentication assigns a new marker and records the
+  previous marker in a durable handoff, so the Store can finish the new login
+  after a crash that occurs before Home Assistant's delayed config-entry save;
+- that predecessor marker authorizes exactly one generation transition through
+  the config-entry mirror fence, after which ordinary generation checks resume;
+- the old manager is retired while holding its session lock, and every
+  config-entry update is tagged with its generation, so late callbacks cannot
+  overwrite the new login.
+
+The durable handoff is written before the config entry is updated. On restart,
+a Store generation whose predecessor matches the config entry is recognized as
+a committed reauthentication and wins. Other mismatches mean the config entry
+is authoritative and stale Store credentials are discarded. The handoff is
+built and saved before the active manager is retired, so a storage failure
+leaves the working generation and session untouched.
+
+Unknown Store fields are preserved to keep future state additions
+forward-compatible.
+
+## Authentication Flow
+
+### Startup
+
+1. Load durable state and reconcile its authentication generation.
+2. Discard durable credentials and sessions from an older login generation.
+3. Apply stored credential updates for the current generation.
+4. If a non-expired Nest session exists, validate it with `app_launch`.
+5. Fall back to credential providers only for an explicit Nest 401/403.
+6. Propagate network errors, rate limits, server failures, and malformed
+   responses as transient setup failures.
+7. Try each available credential provider's complete token, Nest-session, and
+   `app_launch` pipeline in order.
+8. Persist provider rotations before authenticating with Nest.
+9. Clear every candidate session whose validation fails, including on
+   transient errors and cancellation.
+10. Persist the Nest session only after validation succeeds.
+
+### Runtime refresh
+
+1. Acquire the session lock and re-check the current session.
+2. If the caller supplied a rejected session object and a different valid
+   session object is already installed, reuse it.
+3. Clear the rejected or expired persisted Nest session.
+4. For an expired session, try an unexpired cached Google access token once.
+   For an explicitly rejected session, skip the Google token that created it.
+5. If Nest rejects the cached token, acquire a new token through providers.
+6. Persist provider updates before calling Nest.
+7. Validate the new session with `app_launch`.
+8. Persist it only after validation succeeds, then release the lock.
+
+### Credential fallback and retry
+
+A complete attempt tries every available provider. A provider rejected with
+`USER_LOGGED_OUT` or `invalid_grant` does not prevent a later provider from
+succeeding. A provider-specific transient failure also permits an independent
+provider to succeed, but if no provider succeeds the transient outcome takes
+precedence and reauthentication is not started.
+
+Provider fallback covers the whole pipeline, not only Google token acquisition.
+For example, if cookie credentials produce a Nest session that `app_launch`
+rejects, the legacy refresh-token provider still gets its own complete attempt.
+
+After every available provider explicitly rejects its credentials, the manager
+repeats the complete attempt after 1, 5, and 30 seconds. It starts
+reauthentication only after all four attempts are explicit credential
+rejections. If any provider produces an access token but Nest rejects it, the
+outcome is not classified as bad stored credentials.
+
+Retries are not applied blindly:
+
+| Outcome | Coordinator action |
+| --- | --- |
+| Explicit Google `USER_LOGGED_OUT` / `invalid_grant` | Try other providers, then bounded retry; reauth only after exhaustion |
+| Google 401/403 without an explicit rejection code | Treat as transient; never start reauth |
+| Nest session 401/403 | Refresh the session; do not condemn stored credentials |
+| HTTP 429, 5xx, timeout, connection failure | Preserve credentials and retry later; never start reauth |
+| Unexpected or malformed response | Preserve credentials, log safely, and retry later |
+| Successful API operation | Continue; no failure counter is maintained at individual call sites |
+
+## Runtime Consumers
+
+All runtime consumers use the same manager:
+
+- setup uses `async_setup`;
+- subscriber and lock observer pass the exact failed Nest session object to
+  `async_refresh_session`;
+- updatable entities retry one command after coordinated session recovery;
+- lock commands ensure a session and retry once after coordinated recovery;
+- lock observe and command requests receive the same captured session object
+  that their recovery call will report, avoiding mutable-client races;
+- diagnostics uses `ensure_session` and no longer performs direct Google
+  authentication; its actual `app_launch` request also refreshes once on 401.
+
+No runtime caller reads or persists `refreshed_cookies`.
+
+## Low-Level Error Classification
+
+`NestClient` will classify HTTP responses before decoding success payloads:
+
+- 401 and 403 from Nest endpoints raise `NotAuthenticatedException`;
+- 429 and 5xx responses raise `NestServiceException`;
+- explicit Google credential rejection raises `BadCredentialsException`;
+- other invalid responses raise `PynestException`.
+
+This prevents text/plain 401 responses and JSON `access_denied` responses from
+taking different recovery paths. The same classification applies to subscribe
+and update endpoints, including auth errors inside HTTP-200 JSON envelopes.
+Nest x Yale gRPC status code 16 is also mapped to the coordinated auth path.
+
+## Configuration Flow
+
+Config-flow validation uses the same provider factory without a session Store.
+It captures provider updates immediately and retains them across form retries,
+so a Nest failure after Google rotates cookies does not replay the submitted
+stale cookie set. During reauthentication, those updates are also written to a
+separate per-entry pending Store before the downstream Nest call. A fresh flow
+after a Home Assistant restart adopts them only when a fingerprint of the
+resubmitted provider-owned fields and the originating authentication generation
+matches, preventing an unrelated or completed login attempt from receiving
+stale pending data.
+
+On reauthentication, replacement credentials and a fresh authentication
+generation are staged durably before updating the config entry. A live old
+manager is retired under its session lock; if no manager is loaded, the config
+flow writes the same handoff directly. Pending cleanup is best-effort and
+cannot prevent the required reload. Provider-owned fields from the previous
+method are removed, so switching a legacy refresh-token entry to cookies cannot
+silently reactivate the superseded token.
+
+## Testing
+
+Tests will cover:
+
+- cookie rotation is saved before a subsequent Nest failure;
+- a fresh manager after that failure restores and uses the rotated cookie;
+- rotations accompanying a rejected Google response are saved before retry;
+- a rotation during failed reauthentication survives a process restart and is
+  scoped to the matching submitted credential source;
+- config-flow validation and runtime use the same complete provider fallback;
+- a future provider's declared fields participate in hydration, durable replay,
+  and pending-state isolation without coordinator changes;
+- generation creation is durable before the first external auth request;
+- a crash before config-entry mirroring adopts the durable generation;
+- a new reauth generation rejects late durable writes from the old manager;
+- a hard restart during reauth completes from the staged durable handoff;
+- a failed handoff Store write leaves the old manager active;
+- unrelated future Store metadata survives reauthentication;
+- the predecessor-linked handoff advances the real config-entry generation
+  fence and does not persist its internal predecessor marker;
+- refresh-token-only entries still work;
+- switching a refresh-token entry to cookie credentials retires the old token;
+- a rejected cookie provider falls back to a refresh-token provider;
+- failures during the cookie provider's Nest exchange or `app_launch`
+  validation fall back to the refresh-token provider;
+- a failed candidate session is removed from the live client on every
+  validation-failure path;
+- all explicit credential rejections are bounded and eventually request
+  reauthentication;
+- transient failures never request reauthentication;
+- concurrent `ensure_session` calls perform one refresh;
+- concurrent reports of the same rejected session perform one refresh;
+- persisted-session transient failures do not fall back to credentials;
+- setup, subscriber, lock observer, entity, lock command, and diagnostics paths
+  all use the coordinator;
+- JSON and non-JSON 401, 429, and 5xx responses receive the intended exception
+  types;
+- subscribe/update HTTP-200 auth envelopes and gRPC status 16 enter recovery;
+- a real Set-Cookie response survives a downstream Nest failure and fresh
+  manager restart;
+- the full existing suite remains green for both cookie and refresh-token
+  users.
+
+## Readability Constraints
+
+- Provider-specific logic stays in `credentials.py`.
+- Session ordering and persistence stay in `session.py`.
+- Call sites request a valid session and handle domain operations; they do not
+  implement authentication policy.
+- Comments explain ordering or compatibility constraints, not visible code.
+- Retry counts and delays are named constants and injectable in tests.
+- No credential values are logged.

--- a/tests/pynest/test_client.py
+++ b/tests/pynest/test_client.py
@@ -8,6 +8,12 @@ from aiohttp.test_utils import TestServer
 
 from custom_components.nest_protect.pynest.client import NestClient, merge_cookies
 from custom_components.nest_protect.pynest.const import NEST_REQUEST
+from custom_components.nest_protect.pynest.exceptions import (
+    BadCredentialsException,
+    NestServiceException,
+    NotAuthenticatedException,
+    PynestException,
+)
 
 
 @pytest.mark.enable_socket
@@ -38,12 +44,16 @@ async def test_get_access_token_from_cookies_success(socket_enabled):
 
 
 @pytest.mark.enable_socket
-async def test_get_access_token_from_cookies_error(socket_enabled):
-    """Test failure while getting an access token."""
+@pytest.mark.parametrize("status", [200, 400])
+async def test_cookie_invalid_grant_is_bad_credentials(socket_enabled, status):
+    """Explicit cookie rejection must be eligible for provider fallback."""
 
     async def make_token_response(request):
         return web.json_response(
-            {"error": "invalid_grant"}, headers=None, content_type="application/json"
+            {"error": "invalid_grant"},
+            headers=None,
+            content_type="application/json",
+            status=status,
         )
 
     app = web.Application()
@@ -52,7 +62,46 @@ async def test_get_access_token_from_cookies_error(socket_enabled):
     async with TestServer(app) as server, ClientSession() as session:
         nest_client = NestClient(session)
         url = server.make_url("/issue-token")
-        with pytest.raises(Exception, match="invalid_grant"):
+        with pytest.raises(BadCredentialsException, match="invalid_grant"):
+            await nest_client.get_access_token_from_cookies(str(url), "cookies")
+
+
+@pytest.mark.enable_socket
+async def test_refresh_token_invalid_grant_is_bad_credentials(socket_enabled):
+    """An HTTP 400 invalid_grant must reject only the refresh-token provider."""
+
+    async def make_token_response(request):
+        return web.json_response({"error": "invalid_grant"}, status=400)
+
+    app = web.Application()
+    app.router.add_post("/token", make_token_response)
+
+    async with TestServer(app) as server, ClientSession() as session:
+        nest_client = NestClient(session)
+        with (
+            patch(
+                "custom_components.nest_protect.pynest.client.TOKEN_URL",
+                server.make_url("/token"),
+            ),
+            pytest.raises(BadCredentialsException, match="invalid_grant"),
+        ):
+            await nest_client.get_access_token_from_refresh_token("refresh-token")
+
+
+@pytest.mark.enable_socket
+async def test_unclassified_google_forbidden_is_not_bad_credentials(socket_enabled):
+    """A proxy or anti-abuse response must not trigger user reauthentication."""
+
+    async def make_token_response(request):
+        return web.Response(status=403, text="request blocked")
+
+    app = web.Application()
+    app.router.add_get("/issue-token", make_token_response)
+
+    async with TestServer(app) as server, ClientSession() as session:
+        nest_client = NestClient(session)
+        url = server.make_url("/issue-token")
+        with pytest.raises(PynestException, match="403"):
             await nest_client.get_access_token_from_cookies(str(url), "cookies")
 
 
@@ -120,6 +169,176 @@ async def test_get_first_data_success(socket_enabled):
         result.service_urls["urls"]["transport_url"]
         == "https://xxxx.transport.home.nest.com"
     )
+
+
+@pytest.mark.enable_socket
+@pytest.mark.parametrize("status", [401, 403])
+async def test_get_first_data_classifies_auth_status(status, socket_enabled):
+    """Text and JSON authorization failures must use the recovery exception."""
+
+    async def api_response(request):
+        return web.Response(status=status, text="access denied")
+
+    app = web.Application()
+    app.router.add_post("/api/0.1/user/example-user/app_launch", api_response)
+
+    async with TestServer(app) as server, ClientSession() as session:
+        nest_client = NestClient(session)
+        base = str(server.make_url("")).rstrip("/")
+        with (
+            patch.object(nest_client.environment, "host", base),
+            patch(
+                "custom_components.nest_protect.pynest.client.APP_LAUNCH_URL_FORMAT",
+                "{host}/api/0.1/user/{user_id}/app_launch",
+            ),
+            pytest.raises(NotAuthenticatedException),
+        ):
+            await nest_client.get_first_data("access-token", "example-user")
+
+
+@pytest.mark.enable_socket
+@pytest.mark.parametrize("status", [429, 500, 503])
+async def test_get_first_data_classifies_transient_status(status, socket_enabled):
+    """Rate limits and server failures must never look like bad credentials."""
+
+    async def api_response(request):
+        return web.Response(status=status, text="temporarily unavailable")
+
+    app = web.Application()
+    app.router.add_post("/api/0.1/user/example-user/app_launch", api_response)
+
+    async with TestServer(app) as server, ClientSession() as session:
+        nest_client = NestClient(session)
+        base = str(server.make_url("")).rstrip("/")
+        with (
+            patch.object(nest_client.environment, "host", base),
+            patch(
+                "custom_components.nest_protect.pynest.client.APP_LAUNCH_URL_FORMAT",
+                "{host}/api/0.1/user/{user_id}/app_launch",
+            ),
+            pytest.raises(NestServiceException),
+        ):
+            await nest_client.get_first_data("access-token", "example-user")
+
+
+@pytest.mark.enable_socket
+async def test_get_first_data_classifies_json_access_denied(socket_enabled):
+    """A successful HTTP envelope can still carry an explicit auth rejection."""
+
+    async def api_response(request):
+        return web.json_response({"error": "access_denied"})
+
+    app = web.Application()
+    app.router.add_post("/api/0.1/user/example-user/app_launch", api_response)
+
+    async with TestServer(app) as server, ClientSession() as session:
+        nest_client = NestClient(session)
+        base = str(server.make_url("")).rstrip("/")
+        with (
+            patch.object(nest_client.environment, "host", base),
+            patch(
+                "custom_components.nest_protect.pynest.client.APP_LAUNCH_URL_FORMAT",
+                "{host}/api/0.1/user/{user_id}/app_launch",
+            ),
+            pytest.raises(NotAuthenticatedException),
+        ):
+            await nest_client.get_first_data("access-token", "example-user")
+
+
+@pytest.mark.enable_socket
+@pytest.mark.parametrize("operation", ["subscribe", "update"])
+@pytest.mark.parametrize(
+    ("status", "expected_exception"),
+    [
+        (200, NotAuthenticatedException),
+        (403, NotAuthenticatedException),
+        (429, NestServiceException),
+        (503, NestServiceException),
+    ],
+)
+async def test_transport_operations_classify_status_before_json(
+    operation, status, expected_exception, socket_enabled
+):
+    """REST transport failures must enter coordinated recovery."""
+
+    async def api_response(request):
+        return web.json_response({"error": "access_denied"}, status=status)
+
+    app = web.Application()
+    app.router.add_post("/v6/subscribe", api_response)
+    app.router.add_post("/v6/put", api_response)
+
+    async with TestServer(app) as server, ClientSession() as session:
+        nest_client = NestClient(session)
+        transport_url = str(server.make_url("")).rstrip("/")
+
+        if operation == "subscribe":
+            request = nest_client.subscribe_for_data(
+                "access-token", "example-user", transport_url, []
+            )
+        else:
+            request = nest_client.update_objects(
+                "access-token", "example-user", transport_url, {}
+            )
+
+        with pytest.raises(expected_exception):
+            await request
+
+
+@pytest.mark.enable_socket
+@pytest.mark.parametrize(
+    ("status", "expected_exception"),
+    [
+        (401, NotAuthenticatedException),
+        (403, NotAuthenticatedException),
+        (429, NestServiceException),
+        (503, NestServiceException),
+    ],
+)
+async def test_authenticate_classifies_session_status(
+    status, expected_exception, socket_enabled
+):
+    """The Nest session endpoint must classify failures before JSON decoding."""
+
+    async def jwt_response(request):
+        return web.json_response({"jwt": "nest-jwt"})
+
+    async def session_response(request):
+        return web.Response(status=status, text="session failure")
+
+    app = web.Application()
+    app.router.add_post("/jwt", jwt_response)
+    app.router.add_get("/session", session_response)
+
+    async with TestServer(app) as server, ClientSession() as session:
+        nest_client = NestClient(session)
+        base = str(server.make_url("")).rstrip("/")
+        with (
+            patch.object(nest_client.environment, "host", base),
+            patch(
+                "custom_components.nest_protect.pynest.client.NEST_AUTH_URL_JWT",
+                f"{base}/jwt",
+            ),
+            pytest.raises(expected_exception),
+        ):
+            await nest_client.authenticate("google-token")
+
+
+@pytest.mark.enable_socket
+async def test_unknown_google_token_error_uses_pynest_exception(socket_enabled):
+    """Unknown Google failures must remain transient integration failures."""
+
+    async def make_token_response(request):
+        return web.json_response({"error": "temporarily_unavailable"})
+
+    app = web.Application()
+    app.router.add_get("/issue-token", make_token_response)
+
+    async with TestServer(app) as server, ClientSession() as session:
+        nest_client = NestClient(session)
+        url = server.make_url("/issue-token")
+        with pytest.raises(PynestException, match="temporarily_unavailable"):
+            await nest_client.get_access_token_from_cookies(str(url), "cookies")
 
 
 @pytest.mark.enable_socket

--- a/tests/pynest/test_grpc_client.py
+++ b/tests/pynest/test_grpc_client.py
@@ -479,6 +479,17 @@ async def test_send_lock_command_raises_when_gateway_rejects_the_command():
         await client.send_lock_command("X", lock=True)
 
 
+async def test_send_lock_command_maps_unauthenticated_payload():
+    """gRPC status 16 must enter the shared session recovery path."""
+    resp = v1_pb2.SendCommandResponse()
+    resp.status.code = 16
+    resp.status.message = "unauthenticated"
+    client = _make_client(_FakeResponse(body=resp.SerializeToString()))
+
+    with pytest.raises(NestLockAuthException, match="code=16"):
+        await client.send_lock_command("X", lock=True)
+
+
 # -- observe frame parsing ---------------------------------------------------
 
 
@@ -634,6 +645,18 @@ def test_parse_observe_buffer_surfaces_a_gateway_status_frame(caplog):
     assert client._parse_observe_buffer(buffer) == []
     assert "code=7" in caplog.text
     assert "permission denied" in caplog.text
+
+
+def test_parse_observe_buffer_maps_unauthenticated_status():
+    """An HTTP-200 auth status must stop the observer for session recovery."""
+    body = streambody_pb2.StreamBody()
+    body.status.code = 16
+    body.status.message = "unauthenticated"
+    buffer = bytearray(body.SerializeToString())
+
+    client = _make_client()
+    with pytest.raises(NestLockAuthException, match="code=16"):
+        client._parse_observe_buffer(buffer)
 
 
 def test_parse_observe_buffer_ignores_a_zero_status_frame(caplog):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,12 +4,25 @@ import base64
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.nest_protect.const import DOMAIN
-from custom_components.nest_protect.pynest.exceptions import BadCredentialsException
+from custom_components.nest_protect.config_flow import (
+    ConfigFlow,
+    ConfigFlowValidationResult,
+)
+from custom_components.nest_protect.const import (
+    CONF_AUTH_GENERATION,
+    CONF_PREVIOUS_AUTH_GENERATION,
+    DOMAIN,
+)
+from custom_components.nest_protect.pynest.exceptions import (
+    BadCredentialsException,
+    NotAuthenticatedException,
+    PynestException,
+)
 
 
 async def test_step_user_leads_to_auth_method(hass: HomeAssistant) -> None:
@@ -115,6 +128,254 @@ async def test_account_link_stores_refreshed_cookies(
     assert result["data"]["cookies"] == refreshed_cookies
 
 
+async def test_account_link_reuses_rotation_after_nest_validation_failure(
+    hass: HomeAssistant,
+) -> None:
+    """A downstream failure must not make the next attempt replay stale cookies."""
+    issue_token = (
+        "https://accounts.google.com/o/oauth2/iframerpc?action=issueToken&retry=true"
+    )
+    cookies = (
+        "SID=abc123456789012345678901234567890; HSID=def1234567890; "
+        "SSID=ghi1234567890; APISID=jkl1234567890; SAPISID=mno1234567890"
+    )
+    refreshed_cookies = f"{cookies}; __Secure-1PSIDTS=fresh"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"account_type": "production"},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"method": "manual"},
+    )
+
+    client = MagicMock(refreshed_cookies=refreshed_cookies)
+    client.get_access_token_from_cookies = AsyncMock(
+        return_value=MagicMock(access_token="google-token")
+    )
+    client.authenticate = AsyncMock(
+        side_effect=[
+            PynestException("Nest unavailable"),
+            MagicMock(
+                access_token="nest-token",
+                userid="user1",
+                user="user.1",
+            ),
+        ]
+    )
+    client.get_first_data = AsyncMock(
+        return_value=MagicMock(
+            updated_buckets=[
+                MagicMock(object_key="user.1", value={"email": "user@example.com"})
+            ]
+        )
+    )
+    submitted = {"issue_token": issue_token, "cookies": cookies}
+
+    with patch(
+        "custom_components.nest_protect.config_flow.NestClient",
+        return_value=client,
+    ):
+        first_result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=dict(submitted)
+        )
+        second_result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=dict(submitted)
+        )
+
+    assert first_result["type"] is FlowResultType.FORM
+    assert second_result["type"] is FlowResultType.CREATE_ENTRY
+    assert [
+        call.args[1] for call in client.get_access_token_from_cookies.await_args_list
+    ] == [cookies, refreshed_cookies]
+
+
+@pytest.mark.parametrize("generation_changed", [False, True])
+async def test_reauth_rotation_survives_a_flow_process_restart(
+    hass: HomeAssistant,
+    generation_changed: bool,
+) -> None:
+    """Pending rotation survives a restart but cannot cross login generations."""
+    issue_token = (
+        "https://accounts.google.com/o/oauth2/iframerpc?action=issueToken&retry=true"
+    )
+    cookies = "SID=old; HSID=old; SSID=old; APISID=old; SAPISID=old"
+    refreshed_cookies = "SID=new; HSID=old; SSID=old; APISID=old; SAPISID=old"
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "issue_token": issue_token,
+            "cookies": cookies,
+            "account_type": "production",
+            CONF_AUTH_GENERATION: "old-generation",
+        },
+    )
+    entry.add_to_hass(hass)
+    user_input = {
+        "issue_token": issue_token,
+        "cookies": cookies,
+        "account_type": "production",
+    }
+
+    first_client = MagicMock(refreshed_cookies=None)
+
+    async def rotate_cookies(*_):
+        first_client.refreshed_cookies = refreshed_cookies
+        return MagicMock(access_token="google-token")
+
+    first_client.get_access_token_from_cookies = AsyncMock(side_effect=rotate_cookies)
+    first_client.authenticate = AsyncMock(
+        side_effect=PynestException("Nest unavailable")
+    )
+    first_flow = ConfigFlow()
+    first_flow.hass = hass
+    first_flow._config_entry = entry
+
+    with (
+        patch(
+            "custom_components.nest_protect.config_flow.NestClient",
+            return_value=first_client,
+        ),
+        pytest.raises(PynestException, match="Nest unavailable"),
+    ):
+        await first_flow.async_validate_input(user_input)
+
+    if generation_changed:
+        hass.config_entries.async_update_entry(
+            entry,
+            data={**entry.data, CONF_AUTH_GENERATION: "new-generation"},
+        )
+
+    restarted_client = MagicMock(refreshed_cookies=None)
+    restarted_client.get_access_token_from_cookies = AsyncMock(
+        side_effect=PynestException("stop after capture")
+    )
+    if generation_changed:
+        restarted_flow = first_flow
+    else:
+        restarted_flow = ConfigFlow()
+        restarted_flow.hass = hass
+        restarted_flow._config_entry = entry
+
+    with (
+        patch(
+            "custom_components.nest_protect.config_flow.NestClient",
+            return_value=restarted_client,
+        ),
+        pytest.raises(PynestException, match="stop after capture"),
+    ):
+        await restarted_flow.async_validate_input(user_input)
+
+    assert restarted_client.get_access_token_from_cookies.await_args.args[1] == (
+        cookies if generation_changed else refreshed_cookies
+    )
+
+
+async def test_config_validation_falls_back_after_app_launch_rejection(
+    hass: HomeAssistant,
+) -> None:
+    """Config validation must use the complete runtime provider pipeline."""
+    flow = ConfigFlow()
+    flow.hass = hass
+    client = MagicMock(refreshed_cookies=None)
+    client.get_access_token_from_cookies = AsyncMock(
+        return_value=MagicMock(access_token="cookie-google-token")
+    )
+    client.get_access_token_from_refresh_token = AsyncMock(
+        return_value=MagicMock(access_token="fallback-google-token")
+    )
+    client.authenticate = AsyncMock(
+        side_effect=[
+            MagicMock(access_token="cookie-nest-token", userid="user1"),
+            MagicMock(
+                access_token="fallback-nest-token",
+                userid="user1",
+                user="user.1",
+            ),
+        ]
+    )
+    client.get_first_data = AsyncMock(
+        side_effect=[
+            NotAuthenticatedException("401"),
+            MagicMock(
+                updated_buckets=[
+                    MagicMock(object_key="user.1", value={"email": "user@example.com"})
+                ]
+            ),
+        ]
+    )
+
+    with (
+        patch(
+            "custom_components.nest_protect.config_flow.NestClient",
+            return_value=client,
+        ),
+        patch.object(flow, "async_set_unique_id", new_callable=AsyncMock),
+    ):
+        validated = await flow.async_validate_input(
+            {
+                "issue_token": "https://accounts.google.com/issue",
+                "cookies": "SID=current",
+                "refresh_token": "legacy-refresh-token",
+                "account_type": "production",
+            }
+        )
+
+    assert validated.email == "user@example.com"
+    client.get_access_token_from_refresh_token.assert_awaited_once_with(
+        "legacy-refresh-token"
+    )
+
+
+async def test_future_provider_field_changes_reset_pending_updates(
+    hass: HomeAssistant,
+) -> None:
+    """Pending rotations must be scoped by every provider-owned input field."""
+    flow = ConfigFlow()
+    flow.hass = hass
+    seen_credentials = []
+
+    class FutureProvider:
+        name = "future"
+        credential_fields = frozenset({"future_token"})
+
+        def __init__(self, client, save_credentials):
+            self._client = client
+            self._save_credentials = save_credentials
+
+        @property
+        def available(self):
+            return bool(getattr(self._client, "future_token", None))
+
+        async def async_get_access_token(self):
+            seen_credentials.append(self._client.future_token)
+            if len(seen_credentials) == 1:
+                await self._save_credentials({"future_token": "rotated-a"})
+            raise PynestException(f"stop {len(seen_credentials)}")
+
+    def create_future_provider(client, save_credentials):
+        return (FutureProvider(client, save_credentials),)
+
+    with patch(
+        "custom_components.nest_protect.config_flow.create_credential_providers",
+        side_effect=create_future_provider,
+    ):
+        with pytest.raises(PynestException, match="stop 1"):
+            await flow.async_validate_input(
+                {"future_token": "future-a", "account_type": "production"}
+            )
+        with pytest.raises(PynestException, match="stop 2"):
+            await flow.async_validate_input(
+                {"future_token": "future-b", "account_type": "production"}
+            )
+
+    assert seen_credentials == ["future-a", "future-b"]
+
+
 async def test_extension_step_creates_entry(hass: HomeAssistant) -> None:
     """Test extension step decodes code and creates entry on success."""
     issue_token = "https://accounts.google.com/o/oauth2/iframerpc?action=issueToken&response_type=token%20id_token&login_hint=hint123&client_id=733249279899-44tchle2kaa9afr5v9ov7jbuojfr9lrq.apps.googleusercontent.com&origin=https%3A%2F%2Fhome.nest.com&scope=openid+profile+email+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fnest-account&ss_domain=https%3A%2F%2Fhome.nest.com"
@@ -139,7 +400,11 @@ async def test_extension_step_creates_entry(hass: HomeAssistant) -> None:
     with patch(
         "custom_components.nest_protect.config_flow.ConfigFlow.async_validate_input",
         new_callable=AsyncMock,
-        return_value=[issue_token, cookies, "user@example.com"],
+        return_value=ConfigFlowValidationResult(
+            credentials={"issue_token": issue_token, "cookies": cookies},
+            credential_fields=frozenset({"issue_token", "cookies", "refresh_token"}),
+            email="user@example.com",
+        ),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -278,3 +543,103 @@ async def test_reauth_shows_auth_method(hass: HomeAssistant) -> None:
     result = await entry.start_reauth_flow(hass)
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "auth_method"
+
+
+async def test_successful_reauth_stages_new_durable_generation(
+    hass: HomeAssistant,
+) -> None:
+    """New user credentials must not be shadowed by old stored rotations."""
+    old_issue_token = (
+        "https://accounts.google.com/o/oauth2/iframerpc?action=issueToken&old=true"
+    )
+    new_issue_token = (
+        "https://accounts.google.com/o/oauth2/iframerpc?action=issueToken&new=true"
+    )
+    old_cookies = (
+        "SID=old123456789012345678901234567890; HSID=old1234567890; "
+        "SSID=old1234567890; APISID=old1234567890; SAPISID=old1234567890"
+    )
+    new_cookies = (
+        "SID=new123456789012345678901234567890; HSID=new1234567890; "
+        "SSID=new1234567890; APISID=new1234567890; SAPISID=new1234567890"
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "issue_token": old_issue_token,
+            "cookies": old_cookies,
+            "refresh_token": "legacy-refresh-token",
+            "account_type": "production",
+            CONF_AUTH_GENERATION: "old-generation",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"method": "manual"}
+    )
+
+    persistence_events = []
+    original_update_entry = hass.config_entries.async_update_entry
+
+    async def save_handoff(data):
+        persistence_events.append("store")
+
+    def update_entry(*args, **kwargs):
+        persistence_events.append("entry")
+        return original_update_entry(*args, **kwargs)
+
+    with (
+        patch(
+            "custom_components.nest_protect.config_flow.ConfigFlow.async_validate_input",
+            new_callable=AsyncMock,
+            return_value=ConfigFlowValidationResult(
+                credentials={
+                    "issue_token": new_issue_token,
+                    "cookies": new_cookies,
+                },
+                credential_fields=frozenset(
+                    {"issue_token", "cookies", "refresh_token"}
+                ),
+                email="user@example.com",
+            ),
+        ),
+        patch(
+            "custom_components.nest_protect.config_flow.Store.async_save",
+            new_callable=AsyncMock,
+            side_effect=save_handoff,
+        ) as save_store,
+        patch(
+            "custom_components.nest_protect.config_flow.Store.async_remove",
+            new_callable=AsyncMock,
+            side_effect=OSError("cleanup failed"),
+        ) as remove_pending_store,
+        patch.object(
+            hass.config_entries,
+            "async_update_entry",
+            side_effect=update_entry,
+        ),
+        patch.object(
+            hass.config_entries,
+            "async_reload",
+            new_callable=AsyncMock,
+        ) as reload_entry,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"issue_token": new_issue_token, "cookies": new_cookies},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert persistence_events == ["store", "entry"]
+    assert entry.data[CONF_AUTH_GENERATION] != "old-generation"
+    durable_handoff = save_store.await_args.args[0]
+    assert durable_handoff[CONF_AUTH_GENERATION] == entry.data[CONF_AUTH_GENERATION]
+    assert durable_handoff[CONF_PREVIOUS_AUTH_GENERATION] == "old-generation"
+    assert durable_handoff["credentials"]["cookies"] == new_cookies
+    assert "refresh_token" not in durable_handoff["credentials"]
+    assert "refresh_token" not in entry.data
+    remove_pending_store.assert_awaited_once_with()
+    reload_entry.assert_awaited_once_with(entry.entry_id)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,120 @@
+"""Tests for Google credential providers."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.nest_protect.const import (
+    CONF_COOKIES,
+    CONF_ISSUE_TOKEN,
+    CONF_REFRESH_TOKEN,
+)
+from custom_components.nest_protect.credentials import (
+    CookieCredentialProvider,
+    RefreshTokenCredentialProvider,
+    apply_credential_updates,
+    create_credential_providers,
+    credential_field_names,
+)
+from custom_components.nest_protect.pynest.exceptions import BadCredentialsException
+
+
+async def test_cookie_provider_saves_rotation_when_request_is_rejected():
+    """A response-side rotation must survive a rejected token response."""
+    client = MagicMock(
+        issue_token="https://accounts.google.com/issue",
+        cookies="SID=old",
+        refreshed_cookies=None,
+    )
+
+    async def reject_credentials(*_):
+        client.cookies = "SID=new"
+        client.refreshed_cookies = "SID=new"
+        raise BadCredentialsException("USER_LOGGED_OUT")
+
+    client.get_access_token_from_cookies = AsyncMock(side_effect=reject_credentials)
+    save_credentials = AsyncMock()
+    provider = CookieCredentialProvider(client, save_credentials)
+
+    with pytest.raises(BadCredentialsException):
+        await provider.async_get_access_token()
+
+    assert save_credentials.await_args.args[0] == {CONF_COOKIES: "SID=new"}
+
+
+async def test_cookie_provider_does_not_save_unchanged_credentials():
+    """An unchanged response must not cause a redundant durable write."""
+    client = MagicMock(
+        issue_token="https://accounts.google.com/issue",
+        cookies="SID=current",
+        refreshed_cookies=None,
+    )
+    client.get_access_token_from_cookies = AsyncMock(
+        return_value=MagicMock(access_token="google-token")
+    )
+    save_credentials = AsyncMock()
+    provider = CookieCredentialProvider(client, save_credentials)
+
+    auth = await provider.async_get_access_token()
+
+    assert auth.access_token == "google-token"
+    save_credentials.assert_not_awaited()
+
+
+async def test_refresh_token_provider_remains_supported():
+    """Legacy refresh-token entries must acquire tokens independently."""
+    client = MagicMock(refresh_token="legacy-refresh-token")
+    client.get_access_token_from_refresh_token = AsyncMock(
+        return_value=MagicMock(access_token="google-token")
+    )
+    save_credentials = AsyncMock()
+    provider = RefreshTokenCredentialProvider(client, save_credentials)
+
+    auth = await provider.async_get_access_token()
+
+    assert auth.access_token == "google-token"
+    client.get_access_token_from_refresh_token.assert_awaited_once_with(
+        "legacy-refresh-token"
+    )
+    save_credentials.assert_not_awaited()
+
+
+def test_provider_factory_preserves_cookie_then_token_fallback_order():
+    """When both methods exist, cookies remain primary and tokens are fallback."""
+    client = MagicMock(
+        issue_token="https://accounts.google.com/issue",
+        cookies="SID=current",
+        refresh_token="legacy-refresh-token",
+    )
+
+    providers = create_credential_providers(client, AsyncMock())
+
+    assert [provider.name for provider in providers] == ["cookies", "refresh_token"]
+    assert credential_field_names(providers) == {
+        CONF_ISSUE_TOKEN,
+        CONF_COOKIES,
+        CONF_REFRESH_TOKEN,
+    }
+
+
+def test_durable_updates_can_explicitly_clear_a_credential_method():
+    """A future provider must be able to retire superseded credentials."""
+    client = MagicMock(
+        cookies="SID=old",
+        issue_token="old-issue-token",
+        refresh_token="old-refresh-token",
+    )
+
+    apply_credential_updates(
+        client,
+        {
+            CONF_COOKIES: None,
+            CONF_ISSUE_TOKEN: None,
+            CONF_REFRESH_TOKEN: None,
+        },
+        {CONF_COOKIES, CONF_ISSUE_TOKEN, CONF_REFRESH_TOKEN},
+    )
+
+    assert client.cookies is None
+    assert client.issue_token is None
+    assert client.refresh_token is None

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,100 @@
+"""Tests for Nest Protect diagnostics authentication behavior."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.nest_protect import DOMAIN, HomeAssistantNestProtectData
+from custom_components.nest_protect.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+from custom_components.nest_protect.pynest.exceptions import (
+    NotAuthenticatedException,
+)
+from custom_components.nest_protect.pynest.models import FirstDataAPIResponse
+
+from .conftest import COOKIES, ISSUE_TOKEN
+
+
+async def test_diagnostics_uses_the_shared_session_manager(hass):
+    """Diagnostics must not bypass locking or durable credential persistence."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "issue_token": ISSUE_TOKEN,
+            "cookies": COOKIES,
+            "account_type": "production",
+        },
+    )
+    entry.add_to_hass(hass)
+    client = MagicMock()
+    client.nest_session = MagicMock(access_token="nest-token", userid="user1")
+    client.get_access_token_from_cookies = AsyncMock()
+    client.get_access_token_from_refresh_token = AsyncMock()
+    client.authenticate = AsyncMock()
+    client.get_first_data = AsyncMock(
+        return_value=FirstDataAPIResponse(
+            weather_for_structures={},
+            service_urls={"urls": {"transport_url": "https://transport.example.com"}},
+            _2fa_enabled=False,
+            updated_buckets=[],
+        )
+    )
+    session_manager = MagicMock()
+    session_manager.ensure_session = AsyncMock()
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = HomeAssistantNestProtectData(
+        devices={},
+        areas={},
+        client=client,
+        session_manager=session_manager,
+        grpc_lock_client=MagicMock(),
+    )
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert "app_launch" in result
+    session_manager.ensure_session.assert_awaited_once()
+    client.get_access_token_from_cookies.assert_not_awaited()
+    client.get_access_token_from_refresh_token.assert_not_awaited()
+    client.authenticate.assert_not_awaited()
+
+
+async def test_diagnostics_recovers_the_session_rejected_by_its_request(hass):
+    """A time-valid session can still be rejected after ensure_session."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+    rejected_session = MagicMock(access_token="old-token", userid="user1")
+    replacement_session = MagicMock(access_token="new-token", userid="user1")
+    client = MagicMock(nest_session=rejected_session)
+    first_data = FirstDataAPIResponse(
+        weather_for_structures={},
+        service_urls={"urls": {"transport_url": "https://transport.example.com"}},
+        _2fa_enabled=False,
+        updated_buckets=[],
+    )
+    client.get_first_data = AsyncMock(
+        side_effect=[NotAuthenticatedException("401"), first_data]
+    )
+    session_manager = MagicMock()
+    session_manager.ensure_session = AsyncMock()
+
+    async def refresh_session(**kwargs):
+        client.nest_session = replacement_session
+        return True
+
+    session_manager.async_refresh_session = AsyncMock(side_effect=refresh_session)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = HomeAssistantNestProtectData(
+        devices={},
+        areas={},
+        client=client,
+        session_manager=session_manager,
+        grpc_lock_client=MagicMock(),
+    )
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert "app_launch" in result
+    session_manager.async_refresh_session.assert_awaited_once_with(
+        rejected_session=rejected_session
+    )
+    assert client.get_first_data.await_count == 2

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,13 +1,14 @@
 """Tests for the Nest Protect entity base class."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import EntityDescription
 
 from custom_components.nest_protect.const import DOMAIN
-from custom_components.nest_protect.entity import NestEntity
+from custom_components.nest_protect.entity import NestEntity, NestUpdatableEntity
+from custom_components.nest_protect.pynest.exceptions import NotAuthenticatedException
 from custom_components.nest_protect.pynest.models import Bucket
 
 AREAS = {"where.living-room": "Living Room"}
@@ -126,3 +127,45 @@ def test_incomplete_kryptonite_falls_back_to_object_key():
 
     assert device_info["identifiers"] == {(DOMAIN, "kryptonite.5678")}
     assert device_info["name"] == "Nest Temperature Sensor"
+
+
+async def test_updatable_entity_recovers_rejected_session_once():
+    """A write rejected with 401 must retry through the shared coordinator."""
+    bucket = Bucket(
+        object_key="topaz.1234",
+        object_revision=1,
+        object_timestamp=1,
+        value=COMPLETE_TOPAZ,
+    )
+    old_session = MagicMock(access_token="old-token", userid="user1")
+    new_session = MagicMock(access_token="new-token", userid="user1")
+    client = MagicMock(
+        nest_session=old_session,
+        transport_url="https://transport.example.com",
+    )
+    client.update_objects = AsyncMock(
+        side_effect=[NotAuthenticatedException("401"), {"ok": True}]
+    )
+    session_manager = MagicMock()
+    session_manager.ensure_session = AsyncMock()
+
+    async def refresh_session(**kwargs):
+        client.nest_session = new_session
+        return True
+
+    session_manager.async_refresh_session = AsyncMock(side_effect=refresh_session)
+    entity = NestUpdatableEntity(
+        bucket,
+        EntityDescription(key="test"),
+        AREAS,
+        client,
+        session_manager,
+    )
+
+    result = await entity._async_update_objects([{"object_key": "topaz.1234"}])
+
+    assert result == {"ok": True}
+    session_manager.async_refresh_session.assert_awaited_once_with(
+        rejected_session=old_session
+    )
+    assert client.update_objects.await_count == 2

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -11,32 +11,155 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.nest_protect import (
     DOMAIN,
     HomeAssistantNestProtectData,
+    _async_mirror_credentials,
+    _async_observe_locks_loop,
     _async_subscribe_for_data,
+    async_remove_entry,
 )
-from custom_components.nest_protect.const import CONF_COOKIES, MAX_AUTH_FAILURES
-from custom_components.nest_protect.pynest.exceptions import NotAuthenticatedException
+from custom_components.nest_protect.const import (
+    CONF_AUTH_GENERATION,
+    CONF_PREVIOUS_AUTH_GENERATION,
+)
+from custom_components.nest_protect.pynest.exceptions import (
+    BadCredentialsException,
+    NestLockAuthException,
+    NotAuthenticatedException,
+    PynestException,
+)
 from custom_components.nest_protect.session import NestSessionManager
 
 from .conftest import COOKIES, ISSUE_TOKEN, ComponentSetup
 
 
-@pytest.mark.skip(
-    reason="Needs to be fixed. _async_subscribe_for_data should be cancelled when the component is unloaded."
-)
+async def test_stale_manager_cannot_mirror_credentials_after_reauth(hass):
+    """A late callback from the replaced manager must not poison the new login."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "cookies": "SID=new-login",
+            CONF_AUTH_GENERATION: "new-generation",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    await _async_mirror_credentials(
+        hass,
+        entry,
+        {
+            "cookies": "SID=old-rotated",
+            CONF_AUTH_GENERATION: "old-generation",
+        },
+    )
+
+    assert entry.data["cookies"] == "SID=new-login"
+    assert entry.data[CONF_AUTH_GENERATION] == "new-generation"
+
+
+async def test_crash_handoff_can_advance_the_config_entry_generation(hass):
+    """A durable reauth handoff must pass the normal generation fence."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "issue_token": ISSUE_TOKEN,
+            "cookies": "SID=old",
+            CONF_AUTH_GENERATION: "old-generation",
+        },
+    )
+    entry.add_to_hass(hass)
+    client = MagicMock(
+        issue_token=ISSUE_TOKEN,
+        cookies="SID=old",
+        refresh_token=None,
+        refreshed_cookies=None,
+        auth=None,
+        nest_session=None,
+        transport_url=None,
+    )
+    client.get_access_token_from_cookies = AsyncMock(
+        side_effect=PynestException("stop after handoff")
+    )
+    store = MagicMock()
+    store.async_load = AsyncMock(
+        return_value={
+            CONF_AUTH_GENERATION: "new-generation",
+            CONF_PREVIOUS_AUTH_GENERATION: "old-generation",
+            "credentials": {"cookies": "SID=new-login"},
+        }
+    )
+    store.async_save = AsyncMock()
+
+    async def mirror_credentials(updates):
+        await _async_mirror_credentials(hass, entry, updates)
+
+    manager = NestSessionManager(
+        client,
+        store,
+        credential_generation="old-generation",
+        credential_update_callback=mirror_credentials,
+        retry_delays=(),
+    )
+
+    with pytest.raises(PynestException, match="stop after handoff"):
+        await manager.async_setup()
+
+    assert entry.data[CONF_AUTH_GENERATION] == "new-generation"
+    assert entry.data["cookies"] == "SID=new-login"
+    assert CONF_PREVIOUS_AUTH_GENERATION not in entry.data
+
+
+async def test_remove_entry_cleans_session_and_pending_reauth_stores(hass):
+    """Removing an entry must delete both stores that can contain credentials."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+
+    with patch(
+        "custom_components.nest_protect.Store.async_remove",
+        new_callable=AsyncMock,
+    ) as remove_store:
+        await async_remove_entry(hass, entry)
+
+    assert remove_store.await_count == 2
+
+
 async def test_init_with_refresh_token(
     hass,
     component_setup_with_refresh_token: ComponentSetup,
     config_entry_with_refresh_token: MockConfigEntry,
 ):
     """Test initialization."""
+    google_auth = MagicMock(access_token="google-token")
+    nest_session = MagicMock(
+        access_token="nest-token",
+        userid="user1",
+    )
+    nest_session.to_dict.return_value = {"access_token": "nest-token"}
+    first_data = MagicMock(
+        updated_buckets=[],
+        service_urls={"urls": {"transport_url": "https://transport.example.com"}},
+    )
+
     with (
         patch(
-            "custom_components.nest_protect.NestClient.get_access_token_from_refresh_token"
+            "custom_components.nest_protect.NestClient.get_access_token_from_refresh_token",
+            return_value=google_auth,
         ),
-        patch("custom_components.nest_protect.NestClient.authenticate"),
-        patch("custom_components.nest_protect.NestClient.get_first_data"),
+        patch(
+            "custom_components.nest_protect.NestClient.authenticate",
+            return_value=nest_session,
+        ),
+        patch(
+            "custom_components.nest_protect.NestClient.get_first_data",
+            return_value=first_data,
+        ),
         patch("custom_components.nest_protect.Store.async_load", return_value=None),
         patch("custom_components.nest_protect.Store.async_save"),
+        patch(
+            "custom_components.nest_protect._async_subscribe_for_data",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "custom_components.nest_protect._async_observe_locks_loop",
+            new_callable=AsyncMock,
+        ),
     ):
         await component_setup_with_refresh_token()
 
@@ -82,23 +205,46 @@ async def test_authenticate_failure_with_refresh_token(
     assert config_entry_with_refresh_token.state is ConfigEntryState.SETUP_RETRY
 
 
-@pytest.mark.skip(
-    reason="Needs to be fixed. _async_subscribe_for_data should be cancelled when the component is unloaded."
-)
 async def test_init_with_cookies(
     hass,
     component_setup_with_cookies: ComponentSetup,
     config_entry_with_cookies: MockConfigEntry,
 ):
     """Test initialization."""
+    google_auth = MagicMock(access_token="google-token")
+    nest_session = MagicMock(
+        access_token="nest-token",
+        userid="user1",
+    )
+    nest_session.to_dict.return_value = {"access_token": "nest-token"}
+    first_data = MagicMock(
+        updated_buckets=[],
+        service_urls={"urls": {"transport_url": "https://transport.example.com"}},
+    )
+
     with (
         patch(
-            "custom_components.nest_protect.NestClient.get_access_token_from_cookies"
+            "custom_components.nest_protect.NestClient.get_access_token_from_cookies",
+            return_value=google_auth,
         ),
-        patch("custom_components.nest_protect.NestClient.authenticate"),
-        patch("custom_components.nest_protect.NestClient.get_first_data"),
+        patch(
+            "custom_components.nest_protect.NestClient.authenticate",
+            return_value=nest_session,
+        ),
+        patch(
+            "custom_components.nest_protect.NestClient.get_first_data",
+            return_value=first_data,
+        ),
         patch("custom_components.nest_protect.Store.async_load", return_value=None),
         patch("custom_components.nest_protect.Store.async_save"),
+        patch(
+            "custom_components.nest_protect._async_subscribe_for_data",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "custom_components.nest_protect._async_observe_locks_loop",
+            new_callable=AsyncMock,
+        ),
     ):
         await component_setup_with_cookies()
 
@@ -303,18 +449,14 @@ async def test_startup_falls_through_on_401_from_persisted_session(
     assert config_entry_with_cookies.state is ConfigEntryState.LOADED
 
 
-def _make_subscriber_entry_data(
-    hass, entry, consecutive_failures=0, refreshed_cookies=None
-):
+def _make_subscriber_entry_data(hass, entry):
     """Build minimal HomeAssistantNestProtectData for subscriber tests."""
     client = MagicMock()
     client.nest_session = MagicMock(is_expired=lambda buffer_seconds=0: False)
-    client.refreshed_cookies = refreshed_cookies
 
     store = MagicMock()
     store.async_load = AsyncMock(return_value=None)
     sm = NestSessionManager(client, store)
-    sm._consecutive_failures = consecutive_failures
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = HomeAssistantNestProtectData(
         devices={},
@@ -333,8 +475,8 @@ def _make_subscribe_data():
     return data
 
 
-async def test_subscriber_timeout_resets_failure_counter(hass):
-    """TimeoutError resets failure counter — it's not an auth failure."""
+async def test_subscriber_timeout_retries_without_reauthentication(hass):
+    """A long-poll timeout is normal and must not start reauthentication."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -344,20 +486,22 @@ async def test_subscriber_timeout_resets_failure_counter(hass):
         },
     )
     entry.add_to_hass(hass)
-    client, sm = _make_subscriber_entry_data(hass, entry, consecutive_failures=2)
+    client, sm = _make_subscriber_entry_data(hass, entry)
     client.subscribe_for_data = AsyncMock(side_effect=TimeoutError())
 
     with (
-        patch("custom_components.nest_protect._register_subscribe_task"),
+        patch("custom_components.nest_protect._register_subscribe_task") as register,
         patch.object(sm, "ensure_session", new_callable=AsyncMock),
+        patch.object(entry, "async_start_reauth") as start_reauth,
     ):
         await _async_subscribe_for_data(hass, entry, _make_subscribe_data())
 
-    assert sm.consecutive_failures == 0
+    register.assert_called_once()
+    start_reauth.assert_not_called()
 
 
-async def test_subscriber_401_accumulates_failure_counter(hass):
-    """401 path must not reset the counter — repeated 401s should reach MAX_AUTH_FAILURES."""
+async def test_subscriber_401_recovers_the_exact_rejected_session(hass):
+    """A concurrent refresh is de-duplicated against the session that failed."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -367,22 +511,24 @@ async def test_subscriber_401_accumulates_failure_counter(hass):
         },
     )
     entry.add_to_hass(hass)
-    client, sm = _make_subscriber_entry_data(hass, entry, consecutive_failures=0)
+    client, sm = _make_subscriber_entry_data(hass, entry)
+    client.nest_session.access_token = "rejected-token"
+    rejected_session = client.nest_session
     client.subscribe_for_data = AsyncMock(side_effect=NotAuthenticatedException())
 
     with (
         patch("custom_components.nest_protect._register_subscribe_task"),
         patch.object(sm, "ensure_session", new_callable=AsyncMock),
-        patch.object(sm, "async_refresh_session", new_callable=AsyncMock),
+        patch.object(sm, "async_refresh_session", new_callable=AsyncMock) as refresh,
         patch("custom_components.nest_protect.asyncio.sleep", new_callable=AsyncMock),
     ):
         await _async_subscribe_for_data(hass, entry, _make_subscribe_data())
 
-    assert sm.consecutive_failures == 1
+    refresh.assert_awaited_once_with(rejected_session=rejected_session)
 
 
-async def test_subscriber_401_persists_refreshed_cookies(hass):
-    """401 path persists refreshed cookies into the config entry."""
+async def test_subscriber_bad_credentials_requests_reauth_without_escaping(hass):
+    """Exhausted provider rejection must stop the subscriber and start reauth."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -392,26 +538,64 @@ async def test_subscriber_401_persists_refreshed_cookies(hass):
         },
     )
     entry.add_to_hass(hass)
-    new_cookies = "SID=new-sid; HSID=new-hsid"
-    client, sm = _make_subscriber_entry_data(hass, entry, refreshed_cookies=new_cookies)
+    client, sm = _make_subscriber_entry_data(hass, entry)
+    client.nest_session.access_token = "rejected-token"
+    client.subscribe_for_data = AsyncMock(side_effect=NotAuthenticatedException())
+    sm.set_reauthentication_callback(lambda: entry.async_start_reauth(hass))
+
+    with (
+        patch("custom_components.nest_protect._register_subscribe_task") as register,
+        patch.object(sm, "ensure_session", new_callable=AsyncMock),
+        patch.object(
+            sm,
+            "async_refresh_session",
+            new_callable=AsyncMock,
+            side_effect=BadCredentialsException("USER_LOGGED_OUT"),
+        ),
+        patch.object(entry, "async_start_reauth") as start_reauth,
+        patch("custom_components.nest_protect.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await _async_subscribe_for_data(hass, entry, _make_subscribe_data())
+
+    start_reauth.assert_called_once_with(hass)
+    register.assert_not_called()
+
+
+async def test_subscriber_transient_refresh_failure_retries_without_reauth(hass):
+    """A transient coordinator failure must keep the entry and retry later."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "issue_token": ISSUE_TOKEN,
+            "cookies": COOKIES,
+            "account_type": "production",
+        },
+    )
+    entry.add_to_hass(hass)
+    client, sm = _make_subscriber_entry_data(hass, entry)
+    client.nest_session.access_token = "rejected-token"
     client.subscribe_for_data = AsyncMock(side_effect=NotAuthenticatedException())
 
     with (
-        patch("custom_components.nest_protect._register_subscribe_task"),
+        patch("custom_components.nest_protect._register_subscribe_task") as register,
         patch.object(sm, "ensure_session", new_callable=AsyncMock),
-        patch.object(sm, "async_refresh_session", new_callable=AsyncMock),
+        patch.object(
+            sm,
+            "async_refresh_session",
+            new_callable=AsyncMock,
+            side_effect=PynestException("temporary"),
+        ),
+        patch.object(entry, "async_start_reauth") as start_reauth,
         patch("custom_components.nest_protect.asyncio.sleep", new_callable=AsyncMock),
     ):
         await _async_subscribe_for_data(hass, entry, _make_subscribe_data())
 
-    assert entry.data.get(CONF_COOKIES) == new_cookies
-    # In-memory client must also be updated so the next refresh in this HA
-    # session uses fresh cookies (regression guard for bc05166).
-    assert client.cookies == new_cookies
+    start_reauth.assert_not_called()
+    register.assert_called_once()
 
 
-async def test_subscriber_ensure_session_persists_refreshed_cookies(hass):
-    """Proactive session refresh persists refreshed cookies before subscribing."""
+async def test_lock_observer_recovers_the_exact_rejected_session(hass):
+    """Lock and REST failures for one session share one recovery generation."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -421,72 +605,27 @@ async def test_subscriber_ensure_session_persists_refreshed_cookies(hass):
         },
     )
     entry.add_to_hass(hass)
-    new_cookies = "SID=new-sid; HSID=new-hsid"
-    client, sm = _make_subscriber_entry_data(hass, entry, refreshed_cookies=new_cookies)
-    client.subscribe_for_data = AsyncMock(return_value={"objects": []})
+    client, sm = _make_subscriber_entry_data(hass, entry)
+    client.nest_session.access_token = "rejected-token"
+    rejected_session = client.nest_session
 
-    with (
-        patch("custom_components.nest_protect._register_subscribe_task"),
-        patch.object(sm, "ensure_session", new_callable=AsyncMock),
-    ):
-        await _async_subscribe_for_data(hass, entry, _make_subscribe_data())
+    async def rejected_observer():
+        raise NestLockAuthException("401")
+        yield
 
-    assert entry.data.get(CONF_COOKIES) == new_cookies
-    assert client.cookies == new_cookies
+    async def empty_observer():
+        if False:
+            yield
 
-
-async def test_subscriber_401_repeated_failures_triggers_reauth(hass):
-    """Repeated 401s should reach MAX_AUTH_FAILURES and trigger reauth."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            "issue_token": ISSUE_TOKEN,
-            "cookies": COOKIES,
-            "account_type": "production",
-        },
+    grpc_client = hass.data[DOMAIN][entry.entry_id].grpc_lock_client
+    grpc_client.observe_locks = MagicMock(
+        side_effect=[rejected_observer(), empty_observer()]
     )
-    entry.add_to_hass(hass)
-    client, sm = _make_subscriber_entry_data(hass, entry, consecutive_failures=0)
-    client.subscribe_for_data = AsyncMock(side_effect=NotAuthenticatedException())
-
-    # Google still accepts the cookies, so the refresh itself succeeds while Nest
-    # keeps rejecting the session. async_refresh_session is deliberately not
-    # mocked here: it must not reset the failure counter it was called to recover.
-    client.auth = MagicMock(is_expired=lambda: False)
-    client.authenticate = AsyncMock(return_value=MagicMock(to_dict=dict))
-    sm._store.async_save = AsyncMock()
 
     with (
-        patch("custom_components.nest_protect._register_subscribe_task"),
-        patch.object(sm, "ensure_session", new_callable=AsyncMock),
+        patch.object(sm, "async_refresh_session", new_callable=AsyncMock) as refresh,
         patch("custom_components.nest_protect.asyncio.sleep", new_callable=AsyncMock),
-        patch.object(entry, "async_start_reauth") as mock_reauth,
     ):
-        for _ in range(MAX_AUTH_FAILURES):
-            await _async_subscribe_for_data(hass, entry, _make_subscribe_data())
+        await _async_observe_locks_loop(hass, entry)
 
-    assert sm.consecutive_failures == MAX_AUTH_FAILURES
-    mock_reauth.assert_called_once_with(hass)
-
-
-async def test_subscriber_success_resets_failure_counter(hass):
-    """A successful subscribe call must reset the failure counter to zero."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            "issue_token": ISSUE_TOKEN,
-            "cookies": COOKIES,
-            "account_type": "production",
-        },
-    )
-    entry.add_to_hass(hass)
-    client, sm = _make_subscriber_entry_data(hass, entry, consecutive_failures=2)
-    client.subscribe_for_data = AsyncMock(return_value={"objects": []})
-
-    with (
-        patch("custom_components.nest_protect._register_subscribe_task"),
-        patch.object(sm, "ensure_session", new_callable=AsyncMock),
-    ):
-        await _async_subscribe_for_data(hass, entry, _make_subscribe_data())
-
-    assert sm.consecutive_failures == 0
+    refresh.assert_awaited_once_with(rejected_session=rejected_session)

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from homeassistant.helpers import device_registry as dr
@@ -10,6 +10,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.nest_protect.const import DOMAIN
 from custom_components.nest_protect.lock import NestLockEntity
+from custom_components.nest_protect.pynest.exceptions import NestLockAuthException
 from custom_components.nest_protect.pynest.lock_models import LockBoltState, LockState
 
 SERIAL = "ABC123"
@@ -45,7 +46,7 @@ async def added_lock(hass):
     entry.add_to_hass(hass)
 
     initial = _lock_state()
-    entity = NestLockEntity(MagicMock(), initial)
+    entity = NestLockEntity(MagicMock(), initial, MagicMock())
 
     device = dr.async_get(hass).async_get_or_create(
         config_entry_id=entry.entry_id,
@@ -111,3 +112,41 @@ async def test_update_without_a_device_entry_is_a_no_op(hass, added_lock):
         entity._handle_update(_lock_state(location="Front Door"))
 
     assert entity._lock_state.location == "Front Door"
+
+
+async def test_lock_command_recovers_rejected_session_once():
+    """A rejected lock command must refresh once through the coordinator."""
+    grpc_client = MagicMock()
+    grpc_client.send_lock_command = AsyncMock(
+        side_effect=[NestLockAuthException("401"), None]
+    )
+    old_session = MagicMock(access_token="old-token")
+    new_session = MagicMock(access_token="new-token")
+    session_manager = MagicMock(current_session=old_session)
+    session_manager.ensure_session = AsyncMock()
+
+    async def refresh_session(**kwargs):
+        session_manager.current_session = new_session
+        return True
+
+    session_manager.async_refresh_session = AsyncMock(side_effect=refresh_session)
+    entity = NestLockEntity(grpc_client, _lock_state(), session_manager)
+
+    await entity.async_lock()
+
+    session_manager.ensure_session.assert_awaited_once()
+    session_manager.async_refresh_session.assert_awaited_once_with(
+        rejected_session=old_session
+    )
+    assert grpc_client.send_lock_command.await_args_list == [
+        call(
+            entity._lock_state.resource_id,
+            lock=True,
+            nest_session=old_session,
+        ),
+        call(
+            entity._lock_state.resource_id,
+            lock=True,
+            nest_session=new_session,
+        ),
+    ]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2,14 +2,25 @@
 
 from __future__ import annotations
 
+import asyncio
+import copy
 import datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from aiohttp import ClientSession, web
+from aiohttp.test_utils import TestServer
 
-from custom_components.nest_protect.const import BACKOFF_INTERVALS, MAX_AUTH_FAILURES
+from custom_components.nest_protect.const import (
+    CONF_AUTH_GENERATION,
+    CONF_PREVIOUS_AUTH_GENERATION,
+    CONF_REFRESH_TOKEN,
+)
+from custom_components.nest_protect.pynest.client import NestClient
 from custom_components.nest_protect.pynest.exceptions import (
+    BadCredentialsException,
     NotAuthenticatedException,
+    PynestException,
 )
 from custom_components.nest_protect.pynest.models import NestResponse
 from custom_components.nest_protect.session import NestSessionManager
@@ -43,6 +54,936 @@ def _make_first_data() -> MagicMock:
         updated_buckets=[],
         service_urls={"urls": {"transport_url": "https://transport.example.com"}},
     )
+
+
+class _MemoryStore:
+    """Copy values like Home Assistant's JSON-backed Store."""
+
+    def __init__(self, data=None) -> None:
+        self.data = copy.deepcopy(data)
+
+    async def async_load(self):
+        """Return stored state."""
+        return copy.deepcopy(self.data)
+
+    async def async_save(self, data) -> None:
+        """Replace stored state."""
+        self.data = copy.deepcopy(data)
+
+
+def _make_cookie_client(cookies: str = "SID=old") -> MagicMock:
+    """Create a client with explicit auth state for coordinator tests."""
+    client = MagicMock()
+    client.issue_token = "https://accounts.google.com/issue"
+    client.cookies = cookies
+    client.refresh_token = None
+    client.auth = None
+    client.nest_session = None
+    client.transport_url = None
+    client.refreshed_cookies = None
+    client.get_access_token_from_cookies = AsyncMock()
+    client.get_access_token_from_refresh_token = AsyncMock()
+    client.authenticate = AsyncMock()
+    client.get_first_data = AsyncMock(return_value=_make_first_data())
+    return client
+
+
+@pytest.mark.asyncio
+async def test_rotation_survives_nest_failure_and_restart():
+    """A Nest failure after Google rotation must not restore stale cookies."""
+    first_client = _make_cookie_client()
+
+    async def rotate_cookies(*_):
+        first_client.cookies = "SID=new"
+        first_client.refreshed_cookies = "SID=new"
+        return MagicMock(access_token="google-token")
+
+    first_client.get_access_token_from_cookies.side_effect = rotate_cookies
+    first_client.authenticate.side_effect = PynestException("Nest unavailable")
+    store = _MemoryStore()
+    manager = NestSessionManager(first_client, store, retry_delays=())
+
+    with pytest.raises(PynestException):
+        await manager.async_setup()
+
+    assert store.data["credentials"]["cookies"] == "SID=new"
+
+    restarted_client = _make_cookie_client()
+    restarted_client.get_access_token_from_cookies.return_value = MagicMock(
+        access_token="google-token"
+    )
+    restarted_client.authenticate.side_effect = PynestException("stop after capture")
+    restarted_manager = NestSessionManager(
+        restarted_client,
+        store,
+        retry_delays=(),
+    )
+
+    with pytest.raises(PynestException):
+        await restarted_manager.async_setup()
+
+    assert (
+        restarted_client.get_access_token_from_cookies.await_args.args[1] == "SID=new"
+    )
+
+
+@pytest.mark.asyncio
+async def test_durable_update_can_retire_a_config_only_credential():
+    """An explicit clear must not compare equal to an absent Store field."""
+    client = _make_cookie_client()
+    client.refresh_token = "legacy-refresh-token"
+    update_entry = AsyncMock()
+    store = _MemoryStore()
+    manager = NestSessionManager(
+        client,
+        store,
+        credential_update_callback=update_entry,
+        retry_delays=(),
+    )
+    await manager._async_prepare_state()
+
+    await manager._async_save_credentials({CONF_REFRESH_TOKEN: None})
+
+    assert store.data["credentials"][CONF_REFRESH_TOKEN] is None
+    assert client.refresh_token is None
+    assert update_entry.await_args.args[0][CONF_REFRESH_TOKEN] is None
+
+
+@pytest.mark.asyncio
+async def test_future_provider_credentials_are_hydrated_without_core_field_changes():
+    """A registered provider must own hydration of its declared fields."""
+    client = _make_cookie_client()
+    client.issue_token = None
+    client.cookies = None
+    client.authenticate.return_value = _make_nest_response()
+
+    class FutureProvider:
+        name = "future"
+        credential_fields = frozenset({"future_token"})
+
+        @property
+        def available(self):
+            return bool(getattr(client, "future_token", None))
+
+        async def async_get_access_token(self):
+            return MagicMock(access_token="future-google-token")
+
+    manager = NestSessionManager(
+        client,
+        _MemoryStore(),
+        initial_credentials={"future_token": "future-credential"},
+        credential_providers=(FutureProvider(),),
+        retry_delays=(),
+    )
+
+    assert await manager.async_setup() is not None
+    assert client.future_token == "future-credential"
+    client.authenticate.assert_awaited_once_with("future-google-token")
+
+
+@pytest.mark.enable_socket
+async def test_real_cookie_response_rotation_survives_restart(socket_enabled):
+    """Compose HTTP Set-Cookie handling, provider persistence, and restart."""
+    received_cookies = []
+
+    async def issue_token_response(request):
+        received_cookies.append(request.headers["cookie"])
+        response = web.json_response(
+            {
+                "token_type": "Bearer",
+                "access_token": "google-token",
+                "scope": "scope",
+                "login_hint": "hint",
+                "expires_in": 3600,
+                "id_token": "",
+                "session_state": {},
+            }
+        )
+        response.set_cookie("SID", "new")
+        return response
+
+    app = web.Application()
+    app.router.add_get("/issue-token", issue_token_response)
+    store = _MemoryStore()
+
+    async with TestServer(app) as server, ClientSession() as http_session:
+        issue_token = str(server.make_url("/issue-token"))
+        first_client = NestClient(http_session)
+        first_client.issue_token = issue_token
+        first_client.cookies = "SID=old; HSID=keep"
+        first_client.authenticate = AsyncMock(
+            side_effect=PynestException("Nest unavailable")
+        )
+
+        with pytest.raises(PynestException):
+            await NestSessionManager(first_client, store, retry_delays=()).async_setup()
+
+        restarted_client = NestClient(http_session)
+        restarted_client.issue_token = issue_token
+        restarted_client.cookies = "SID=old; HSID=keep"
+        restarted_client.authenticate = AsyncMock(
+            side_effect=PynestException("stop after capture")
+        )
+
+        with pytest.raises(PynestException):
+            await NestSessionManager(
+                restarted_client, store, retry_delays=()
+            ).async_setup()
+
+    assert received_cookies == ["SID=old; HSID=keep", "SID=new; HSID=keep"]
+
+
+@pytest.mark.asyncio
+async def test_rotation_from_rejected_response_is_used_by_retry():
+    """A rotation accompanying USER_LOGGED_OUT must feed the next attempt."""
+    client = _make_cookie_client()
+
+    async def reject_with_rotation(*_):
+        if client.cookies == "SID=old":
+            client.cookies = "SID=new"
+            client.refreshed_cookies = "SID=new"
+        raise BadCredentialsException("USER_LOGGED_OUT")
+
+    client.get_access_token_from_cookies.side_effect = reject_with_rotation
+    store = _MemoryStore()
+    manager = NestSessionManager(client, store, retry_delays=(0,))
+
+    with pytest.raises(BadCredentialsException):
+        await manager.async_setup()
+
+    assert [
+        call.args[1] for call in client.get_access_token_from_cookies.await_args_list
+    ] == ["SID=old", "SID=new"]
+    assert store.data["credentials"]["cookies"] == "SID=new"
+
+
+@pytest.mark.asyncio
+async def test_cookie_rejection_falls_back_to_refresh_token():
+    """An alternate configured provider must be tried before reauthentication."""
+    client = _make_cookie_client()
+    client.refresh_token = "legacy-refresh-token"
+    client.get_access_token_from_cookies.side_effect = BadCredentialsException(
+        "USER_LOGGED_OUT"
+    )
+    client.get_access_token_from_refresh_token.return_value = MagicMock(
+        access_token="fallback-google-token"
+    )
+    new_session = _make_nest_response()
+    client.authenticate.return_value = new_session
+    store = _MemoryStore()
+    manager = NestSessionManager(client, store, retry_delays=())
+
+    result = await manager.async_setup()
+
+    assert result is not None
+    client.get_access_token_from_refresh_token.assert_awaited_once_with(
+        "legacy-refresh-token"
+    )
+    client.authenticate.assert_awaited_once_with("fallback-google-token")
+
+
+@pytest.mark.asyncio
+async def test_cookie_transient_failure_falls_back_to_refresh_token():
+    """An independent provider can recover without misclassifying the first."""
+    client = _make_cookie_client()
+    client.refresh_token = "legacy-refresh-token"
+    client.get_access_token_from_cookies.side_effect = PynestException(
+        "cookie endpoint changed"
+    )
+    client.get_access_token_from_refresh_token.return_value = MagicMock(
+        access_token="fallback-google-token"
+    )
+    client.authenticate.return_value = _make_nest_response()
+    manager = NestSessionManager(client, _MemoryStore(), retry_delays=())
+
+    assert await manager.async_setup() is not None
+
+    client.get_access_token_from_refresh_token.assert_awaited_once_with(
+        "legacy-refresh-token"
+    )
+    client.authenticate.assert_awaited_once_with("fallback-google-token")
+
+
+@pytest.mark.asyncio
+async def test_cookie_app_launch_rejection_falls_back_to_refresh_token():
+    """Each provider must get a complete Nest validation attempt."""
+    client = _make_cookie_client()
+    client.refresh_token = "legacy-refresh-token"
+    client.get_access_token_from_cookies.return_value = MagicMock(
+        access_token="cookie-google-token"
+    )
+    client.get_access_token_from_refresh_token.return_value = MagicMock(
+        access_token="fallback-google-token"
+    )
+    client.authenticate.side_effect = [
+        _make_nest_response(),
+        _make_nest_response(),
+    ]
+    client.get_first_data.side_effect = [
+        NotAuthenticatedException("401"),
+        _make_first_data(),
+    ]
+    manager = NestSessionManager(client, _MemoryStore(), retry_delays=())
+
+    assert await manager.async_setup() is not None
+
+    client.get_access_token_from_refresh_token.assert_awaited_once_with(
+        "legacy-refresh-token"
+    )
+    assert [call.args[0] for call in client.authenticate.await_args_list] == [
+        "cookie-google-token",
+        "fallback-google-token",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cookie_nest_exchange_failure_falls_back_to_refresh_token():
+    """A provider-specific pipeline failure must not skip another method."""
+    client = _make_cookie_client()
+    client.refresh_token = "legacy-refresh-token"
+    client.get_access_token_from_cookies.return_value = MagicMock(
+        access_token="cookie-google-token"
+    )
+    client.get_access_token_from_refresh_token.return_value = MagicMock(
+        access_token="fallback-google-token"
+    )
+    client.authenticate.side_effect = [
+        PynestException("cookie session exchange failed"),
+        _make_nest_response(),
+    ]
+    manager = NestSessionManager(client, _MemoryStore(), retry_delays=())
+
+    assert await manager.async_setup() is not None
+
+    client.get_access_token_from_refresh_token.assert_awaited_once_with(
+        "legacy-refresh-token"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mixed_bad_and_transient_provider_failures_do_not_start_reauth():
+    """Any transient provider outcome keeps mixed evidence out of reauth."""
+    client = _make_cookie_client()
+    client.refresh_token = "legacy-refresh-token"
+    client.get_access_token_from_cookies.side_effect = BadCredentialsException(
+        "USER_LOGGED_OUT"
+    )
+    client.get_access_token_from_refresh_token.side_effect = PynestException(
+        "temporary token endpoint failure"
+    )
+    manager = NestSessionManager(client, _MemoryStore(), retry_delays=(0, 0))
+    start_reauth = MagicMock()
+    manager.set_reauthentication_callback(start_reauth)
+
+    with pytest.raises(PynestException, match="temporary"):
+        await manager.async_setup()
+
+    start_reauth.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reauthentication_requires_every_provider_to_reject_every_attempt():
+    """Only repeated explicit provider rejection may request reauthentication."""
+    client = _make_cookie_client()
+    client.refresh_token = "legacy-refresh-token"
+    client.get_access_token_from_cookies.side_effect = BadCredentialsException(
+        "USER_LOGGED_OUT"
+    )
+    client.get_access_token_from_refresh_token.side_effect = BadCredentialsException(
+        "invalid_grant"
+    )
+    store = _MemoryStore()
+    manager = NestSessionManager(client, store, retry_delays=(0, 0))
+    start_reauth = MagicMock()
+    manager.set_reauthentication_callback(start_reauth)
+
+    with pytest.raises(BadCredentialsException):
+        await manager.async_setup()
+
+    assert client.get_access_token_from_cookies.await_count == 3
+    assert client.get_access_token_from_refresh_token.await_count == 3
+    start_reauth.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_setup_retries_session_rejected_by_app_launch():
+    """A rejected new Nest session must get a fresh complete auth attempt."""
+    client = _make_cookie_client()
+    client.get_access_token_from_cookies.return_value = MagicMock(
+        access_token="google-token"
+    )
+    client.authenticate.side_effect = [
+        _make_nest_response(),
+        _make_nest_response(),
+    ]
+    client.get_first_data.side_effect = [
+        NotAuthenticatedException("401"),
+        _make_first_data(),
+    ]
+    manager = NestSessionManager(client, _MemoryStore(), retry_delays=(0,))
+
+    assert await manager.async_setup() is not None
+    assert client.get_access_token_from_cookies.await_count == 2
+    assert client.authenticate.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_nest_token_rejection_does_not_start_reauthentication():
+    """A usable Google credential with Nest rejection is not a bad credential."""
+    client = _make_cookie_client()
+    client.get_access_token_from_cookies.return_value = MagicMock(
+        access_token="google-token"
+    )
+    client.authenticate.side_effect = NotAuthenticatedException("401")
+    manager = NestSessionManager(client, _MemoryStore(), retry_delays=(0,))
+    start_reauth = MagicMock()
+    manager.set_reauthentication_callback(start_reauth)
+
+    with pytest.raises(NotAuthenticatedException):
+        await manager.async_setup()
+
+    assert client.get_access_token_from_cookies.await_count == 2
+    start_reauth.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_mixed_nest_and_credential_rejections_do_not_start_reauth():
+    """Any usable Google token keeps mixed failures out of reauthentication."""
+    client = _make_cookie_client()
+    client.get_access_token_from_cookies.side_effect = [
+        MagicMock(access_token="google-token"),
+        BadCredentialsException("USER_LOGGED_OUT"),
+        BadCredentialsException("USER_LOGGED_OUT"),
+    ]
+    client.authenticate.side_effect = NotAuthenticatedException("401")
+    manager = NestSessionManager(client, _MemoryStore(), retry_delays=(0, 0))
+    start_reauth = MagicMock()
+    manager.set_reauthentication_callback(start_reauth)
+
+    with pytest.raises(NotAuthenticatedException):
+        await manager.async_setup()
+
+    start_reauth.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unexpected_persisted_session_failure_does_not_use_credentials():
+    """Malformed or unexpected Nest responses must not condemn credentials."""
+    valid_session = _make_nest_response()
+    store = _MemoryStore(
+        {
+            "nest_session": valid_session.to_dict(),
+            "transport_url": "https://transport.example.com",
+        }
+    )
+    client = _make_cookie_client()
+    client.get_first_data.side_effect = PynestException("malformed response")
+    manager = NestSessionManager(client, store, retry_delays=())
+
+    with pytest.raises(PynestException):
+        await manager.async_setup()
+
+    client.get_access_token_from_cookies.assert_not_awaited()
+    assert client.nest_session is None
+    assert store.data["nest_session"] == valid_session.to_dict()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_ensure_session_calls_share_one_refresh():
+    """Concurrent consumers must not perform duplicate credential exchanges."""
+    client = _make_cookie_client()
+    token_request_started = asyncio.Event()
+    release_token_request = asyncio.Event()
+
+    async def acquire_token(*_):
+        token_request_started.set()
+        await release_token_request.wait()
+        return MagicMock(access_token="google-token")
+
+    client.get_access_token_from_cookies.side_effect = acquire_token
+    client.authenticate.return_value = _make_nest_response()
+    manager = NestSessionManager(client, _MemoryStore(), retry_delays=())
+
+    first = asyncio.create_task(manager.ensure_session())
+    await token_request_started.wait()
+    second = asyncio.create_task(manager.ensure_session())
+    release_token_request.set()
+    await asyncio.gather(first, second)
+
+    client.get_access_token_from_cookies.assert_awaited_once()
+    client.authenticate.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ensure_session_without_credentials_requests_reauthentication():
+    """Runtime recovery without any provider must fail explicitly."""
+    client = _make_cookie_client()
+    client.issue_token = None
+    client.cookies = None
+    client.refresh_token = None
+    manager = NestSessionManager(client, _MemoryStore(), retry_delays=())
+    start_reauth = MagicMock()
+    manager.set_reauthentication_callback(start_reauth)
+
+    with pytest.raises(BadCredentialsException, match="No credentials"):
+        await manager.ensure_session()
+
+    start_reauth.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_rejections_of_same_session_share_one_refresh():
+    """A second report about an already-replaced session reuses its replacement."""
+    client = _make_cookie_client()
+    old_session = _make_nest_response()
+    old_session.access_token = "same-nest-token"
+    client.nest_session = old_session
+    client.get_access_token_from_cookies.return_value = MagicMock(
+        access_token="google-token"
+    )
+    new_session = _make_nest_response()
+    new_session.access_token = "same-nest-token"
+    client.authenticate.return_value = new_session
+    manager = NestSessionManager(client, _MemoryStore(), retry_delays=())
+
+    await asyncio.gather(
+        manager.async_refresh_session(rejected_session=old_session),
+        manager.async_refresh_session(rejected_session=old_session),
+    )
+
+    client.get_access_token_from_cookies.assert_awaited_once()
+    client.authenticate.assert_awaited_once()
+    assert client.nest_session is new_session
+
+
+@pytest.mark.asyncio
+async def test_rejected_session_skips_the_google_token_that_created_it():
+    """Explicit rejection must reach providers instead of looping cached auth."""
+    client = _make_cookie_client()
+    rejected_session = _make_nest_response()
+    client.nest_session = rejected_session
+    client.auth = MagicMock(access_token="cached-google-token")
+    client.auth.is_expired.return_value = False
+    client.get_access_token_from_cookies.return_value = MagicMock(
+        access_token="fresh-google-token"
+    )
+    replacement = _make_nest_response()
+    client.authenticate.return_value = replacement
+    manager = NestSessionManager(client, _MemoryStore(), retry_delays=())
+
+    await manager.async_refresh_session(rejected_session=rejected_session)
+
+    client.authenticate.assert_awaited_once_with("fresh-google-token")
+    assert client.nest_session is replacement
+
+
+@pytest.mark.asyncio
+async def test_runtime_refresh_does_not_persist_an_unvalidated_session():
+    """A new session rejected by app_launch must never become durable."""
+    client = _make_cookie_client()
+    rejected_session = _make_nest_response()
+    client.nest_session = rejected_session
+    client.get_access_token_from_cookies.return_value = MagicMock(
+        access_token="fresh-google-token"
+    )
+    candidate = _make_nest_response()
+
+    async def install_candidate(*_):
+        client.nest_session = candidate
+        return candidate
+
+    client.authenticate.side_effect = install_candidate
+    client.get_first_data.side_effect = NotAuthenticatedException("401")
+    store = _MemoryStore()
+    manager = NestSessionManager(client, store, retry_delays=())
+
+    with pytest.raises(NotAuthenticatedException):
+        await manager.async_refresh_session(rejected_session=rejected_session)
+
+    assert client.nest_session is None
+    assert "nest_session" not in store.data
+
+
+@pytest.mark.asyncio
+async def test_cached_auth_rejection_clears_the_clients_candidate_session():
+    """NestClient installs candidates before app_launch validation completes."""
+    client = _make_cookie_client()
+    client.issue_token = None
+    client.cookies = None
+    client.auth = MagicMock(access_token="cached-google-token")
+    client.auth.is_expired.return_value = False
+    candidate = _make_nest_response()
+
+    async def install_candidate(*_):
+        client.nest_session = candidate
+        return candidate
+
+    client.authenticate.side_effect = install_candidate
+    client.get_first_data.side_effect = NotAuthenticatedException("401")
+    manager = NestSessionManager(client, _MemoryStore(), retry_delays=())
+
+    with pytest.raises(BadCredentialsException, match="No credentials"):
+        await manager.ensure_session()
+
+    assert client.nest_session is None
+
+
+@pytest.mark.asyncio
+async def test_transient_validation_failure_clears_the_clients_candidate_session():
+    """A transient app_launch failure must not make its candidate reusable."""
+    client = _make_cookie_client()
+    client.get_access_token_from_cookies.return_value = MagicMock(
+        access_token="google-token"
+    )
+    candidate = _make_nest_response()
+
+    async def install_candidate(*_):
+        client.nest_session = candidate
+        return candidate
+
+    client.authenticate.side_effect = install_candidate
+    client.get_first_data.side_effect = PynestException("Nest unavailable")
+    manager = NestSessionManager(client, _MemoryStore(), retry_delays=())
+
+    with pytest.raises(PynestException, match="Nest unavailable"):
+        await manager.ensure_session()
+
+    assert client.nest_session is None
+
+
+@pytest.mark.asyncio
+async def test_rejected_replacement_can_be_invalidated_without_another_refresh():
+    """A consumer's second 401 must remove the unusable durable session."""
+    rejected_session = _make_nest_response()
+    store = _MemoryStore(
+        {
+            "nest_session": rejected_session.to_dict(),
+            "transport_url": "https://transport.example.com",
+        }
+    )
+    client = _make_cookie_client()
+    client.nest_session = rejected_session
+    manager = NestSessionManager(client, store, retry_delays=())
+
+    await manager.async_invalidate_session(rejected_session=rejected_session)
+
+    assert client.nest_session is None
+    assert client.auth is None
+    assert "nest_session" not in store.data
+    assert "transport_url" not in store.data
+
+
+@pytest.mark.asyncio
+async def test_ensure_session_waits_for_refresh_in_progress():
+    """A valid-looking rejected session must not escape during replacement."""
+    load_started = asyncio.Event()
+    release_load = asyncio.Event()
+
+    class BlockingStore(_MemoryStore):
+        async def async_load(self):
+            load_started.set()
+            await release_load.wait()
+            return await super().async_load()
+
+    client = _make_cookie_client()
+    rejected_session = _make_nest_response()
+    client.nest_session = rejected_session
+    client.get_access_token_from_cookies.return_value = MagicMock(
+        access_token="google-token"
+    )
+    replacement = _make_nest_response()
+    client.authenticate.return_value = replacement
+    manager = NestSessionManager(client, BlockingStore(), retry_delays=())
+
+    refresh = asyncio.create_task(
+        manager.async_refresh_session(rejected_session=rejected_session)
+    )
+    await load_started.wait()
+    ensure = asyncio.create_task(manager.ensure_session())
+    await asyncio.sleep(0)
+
+    assert not ensure.done()
+
+    release_load.set()
+    await asyncio.gather(refresh, ensure)
+    assert client.nest_session is replacement
+
+
+@pytest.mark.asyncio
+async def test_stored_credentials_are_applied_before_session_validation():
+    """The durable rotation must be live even when the Nest session is reusable."""
+    valid_session = _make_nest_response()
+    store = _MemoryStore(
+        {
+            "credentials": {"cookies": "SID=new"},
+            "nest_session": valid_session.to_dict(),
+            "transport_url": "https://transport.example.com",
+        }
+    )
+    client = _make_cookie_client()
+
+    async def validate_session(*_):
+        assert client.cookies == "SID=new"
+        return _make_first_data()
+
+    client.get_first_data.side_effect = validate_session
+    manager = NestSessionManager(client, store, retry_delays=())
+
+    assert await manager.async_setup() is not None
+
+
+@pytest.mark.asyncio
+async def test_malformed_persisted_session_is_removed_before_fallback():
+    """A corrupt expiry must not trap every setup retry on the same Store data."""
+    malformed_session = _make_nest_response().to_dict()
+    malformed_session["expires_in"] = "3600"
+    store = _MemoryStore(
+        {
+            "nest_session": malformed_session,
+            "transport_url": "https://transport.example.com",
+        }
+    )
+    client = _make_cookie_client()
+    client.get_access_token_from_cookies.side_effect = PynestException("stop")
+    manager = NestSessionManager(client, store, retry_delays=())
+
+    with pytest.raises(PynestException, match="stop"):
+        await manager.async_setup()
+
+    assert "nest_session" not in store.data
+    assert "transport_url" not in store.data
+
+
+@pytest.mark.asyncio
+async def test_missing_entry_generation_adopts_durable_generation():
+    """A crash before config-entry save must retain the Store generation."""
+    valid_session = _make_nest_response()
+    store = _MemoryStore(
+        {
+            CONF_AUTH_GENERATION: "durable-generation",
+            "credentials": {"cookies": "SID=new"},
+            "nest_session": valid_session.to_dict(),
+            "transport_url": "https://transport.example.com",
+        }
+    )
+    client = _make_cookie_client()
+    update_entry = AsyncMock()
+    manager = NestSessionManager(
+        client,
+        store,
+        credential_generation=None,
+        credential_update_callback=update_entry,
+        retry_delays=(),
+    )
+
+    assert await manager.async_setup() is not None
+    assert client.cookies == "SID=new"
+    assert {CONF_AUTH_GENERATION: "durable-generation"} in [
+        call.args[0] for call in update_entry.await_args_list
+    ]
+
+
+@pytest.mark.asyncio
+async def test_new_credential_generation_discards_old_durable_auth_state():
+    """A completed reauth must ignore late writes from the previous manager."""
+    old_session = _make_nest_response()
+    store = _MemoryStore(
+        {
+            CONF_AUTH_GENERATION: "old-generation",
+            "credentials": {"cookies": "SID=old"},
+            "nest_session": old_session.to_dict(),
+            "transport_url": "https://old-transport.example.com",
+        }
+    )
+    client = _make_cookie_client(cookies="SID=new-login")
+    client.get_access_token_from_cookies.return_value = MagicMock(
+        access_token="google-token"
+    )
+    client.authenticate.side_effect = PynestException("stop after credentials")
+    manager = NestSessionManager(
+        client,
+        store,
+        credential_generation="new-generation",
+        retry_delays=(),
+    )
+
+    with pytest.raises(PynestException):
+        await manager.async_setup()
+
+    client.get_first_data.assert_not_awaited()
+    assert client.get_access_token_from_cookies.await_args.args[1] == "SID=new-login"
+    assert store.data == {CONF_AUTH_GENERATION: "new-generation"}
+
+
+@pytest.mark.asyncio
+async def test_durable_reauthentication_handoff_wins_after_a_crash():
+    """A staged new login must survive before config-entry persistence."""
+    store = _MemoryStore(
+        {
+            CONF_AUTH_GENERATION: "new-generation",
+            CONF_PREVIOUS_AUTH_GENERATION: "old-generation",
+            "credentials": {"cookies": "SID=new-login"},
+        }
+    )
+    client = _make_cookie_client(cookies="SID=old")
+    client.get_access_token_from_cookies.side_effect = PynestException("stop")
+    update_entry = AsyncMock()
+    manager = NestSessionManager(
+        client,
+        store,
+        credential_generation="old-generation",
+        credential_update_callback=update_entry,
+        retry_delays=(),
+    )
+
+    with pytest.raises(PynestException, match="stop"):
+        await manager.async_setup()
+
+    assert client.cookies == "SID=new-login"
+    assert {
+        CONF_AUTH_GENERATION: "new-generation",
+        CONF_PREVIOUS_AUTH_GENERATION: "old-generation",
+    } in [call.args[0] for call in update_entry.await_args_list]
+
+
+@pytest.mark.asyncio
+async def test_staging_reauthentication_retires_the_old_manager():
+    """The old manager must finish all writes before the new state is staged."""
+    store = _MemoryStore()
+    client = _make_cookie_client()
+    manager = NestSessionManager(
+        client,
+        store,
+        credential_generation="old-generation",
+        retry_delays=(),
+    )
+
+    await manager.async_stage_reauthentication(
+        "new-generation",
+        {"cookies": "SID=new-login"},
+    )
+
+    assert store.data == {
+        CONF_AUTH_GENERATION: "new-generation",
+        CONF_PREVIOUS_AUTH_GENERATION: "old-generation",
+        "credentials": {"cookies": "SID=new-login"},
+    }
+    with pytest.raises(NotAuthenticatedException, match="replaced"):
+        await manager.ensure_session()
+
+
+@pytest.mark.asyncio
+async def test_failed_reauthentication_stage_keeps_the_old_manager_active():
+    """A failed durable handoff must leave the loaded integration usable."""
+
+    class FailingStore(_MemoryStore):
+        async def async_save(self, data) -> None:
+            raise OSError("disk full")
+
+    old_session = _make_nest_response()
+    client = _make_cookie_client()
+    client.nest_session = old_session
+    manager = NestSessionManager(
+        client,
+        FailingStore(),
+        credential_generation="old-generation",
+        retry_delays=(),
+    )
+
+    with pytest.raises(OSError, match="disk full"):
+        await manager.async_stage_reauthentication(
+            "new-generation",
+            {"cookies": "SID=new-login"},
+        )
+
+    await manager.ensure_session()
+    assert manager.current_session is old_session
+
+
+@pytest.mark.asyncio
+async def test_cancelled_reauthentication_stage_keeps_the_old_manager_active():
+    """Cancellation before the durable handoff must not retire the manager."""
+    save_started = asyncio.Event()
+
+    class BlockingStore(_MemoryStore):
+        async def async_save(self, data) -> None:
+            save_started.set()
+            await asyncio.Event().wait()
+
+    old_session = _make_nest_response()
+    client = _make_cookie_client()
+    client.nest_session = old_session
+    manager = NestSessionManager(
+        client,
+        BlockingStore(),
+        credential_generation="old-generation",
+        retry_delays=(),
+    )
+    staging = asyncio.create_task(
+        manager.async_stage_reauthentication(
+            "new-generation",
+            {"cookies": "SID=new-login"},
+        )
+    )
+    await save_started.wait()
+
+    staging.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await staging
+
+    await manager.ensure_session()
+    assert manager.current_session is old_session
+
+
+@pytest.mark.asyncio
+async def test_staging_reauthentication_preserves_unknown_durable_state():
+    """A future provider's independent Store metadata must survive reauth."""
+    store = _MemoryStore({"future_provider_state": {"cursor": "opaque"}})
+    manager = NestSessionManager(
+        _make_cookie_client(),
+        store,
+        credential_generation="old-generation",
+        retry_delays=(),
+    )
+
+    await manager.async_stage_reauthentication(
+        "new-generation",
+        {"cookies": "SID=new-login"},
+    )
+
+    assert store.data["future_provider_state"] == {"cursor": "opaque"}
+
+
+@pytest.mark.asyncio
+async def test_first_generation_is_durable_before_authentication():
+    """An upgraded entry must save its generation before external requests."""
+    client = _make_cookie_client()
+    events = []
+
+    async def update_entry(updates):
+        events.append(("entry", updates))
+
+    async def request_token(*_):
+        events.append(("google", None))
+        raise PynestException("stop")
+
+    client.get_access_token_from_cookies.side_effect = request_token
+    store = _MemoryStore()
+    manager = NestSessionManager(
+        client,
+        store,
+        credential_generation=None,
+        credential_update_callback=update_entry,
+        retry_delays=(),
+    )
+
+    with pytest.raises(PynestException):
+        await manager.async_setup()
+
+    generation = store.data[CONF_AUTH_GENERATION]
+    assert generation
+    assert events[0] == ("entry", {CONF_AUTH_GENERATION: generation})
+    assert events[1] == ("google", None)
 
 
 @pytest.mark.asyncio
@@ -117,8 +1058,9 @@ async def test_restore_expired_session_falls_through():
     # Should have fallen through to cookie auth
     client.get_access_token_from_cookies.assert_called_once()
     client.authenticate.assert_called_once_with("new-google-token")
-    # Should have persisted the new session
-    store.async_save.assert_called_once()
+    assert store.async_save.await_args.args[0]["nest_session"] == (
+        new_nest_session.to_dict()
+    )
 
 
 @pytest.mark.asyncio
@@ -163,8 +1105,9 @@ async def test_restore_rejected_session_falls_through():
     # Should have fallen through to cookie auth after 401
     client.get_access_token_from_cookies.assert_called_once()
     client.authenticate.assert_called_once_with("new-google-token")
-    # Should have persisted the new session
-    store.async_save.assert_called_once()
+    assert store.async_save.await_args.args[0]["nest_session"] == (
+        new_nest_session.to_dict()
+    )
 
 
 @pytest.mark.asyncio
@@ -198,7 +1141,11 @@ async def test_no_persisted_session_uses_cookies():
     client.get_access_token_from_cookies.assert_called_once()
     client.authenticate.assert_called_once_with("google-token")
     # Should have persisted the session
-    store.async_save.assert_called_once()
+    store.async_save.assert_awaited()
+    assert (
+        store.async_save.await_args.args[0]["nest_session"]
+        == new_nest_session.to_dict()
+    )
 
 
 @pytest.mark.asyncio
@@ -214,6 +1161,7 @@ async def test_ensure_session_valid():
     client.authenticate = AsyncMock()
 
     store = MagicMock()
+    store.async_load = AsyncMock(return_value=None)
     store.async_save = AsyncMock()
 
     manager = NestSessionManager(client=client, store=store)
@@ -238,8 +1186,10 @@ async def test_ensure_session_expired_refreshes():
     client.auth = MagicMock(access_token="existing-google-token")
     client.auth.is_expired = MagicMock(return_value=False)
     client.authenticate = AsyncMock(return_value=new_session)
+    client.get_first_data = AsyncMock(return_value=_make_first_data())
 
     store = MagicMock()
+    store.async_load = AsyncMock(return_value=None)
     store.async_save = AsyncMock()
 
     manager = NestSessionManager(client=client, store=store)
@@ -249,7 +1199,8 @@ async def test_ensure_session_expired_refreshes():
     # Should have authenticated with the existing Google token
     client.authenticate.assert_called_once_with("existing-google-token")
     # Should have persisted the new session
-    store.async_save.assert_called_once()
+    store.async_save.assert_awaited()
+    assert store.async_save.await_args.args[0]["nest_session"] == new_session.to_dict()
     # Should have set the new session on the client
     assert client.nest_session == new_session
 
@@ -262,110 +1213,31 @@ async def test_ensure_session_none_refreshes():
     client = MagicMock()
     client.nest_session = None
     client.auth = None
+    client.issue_token = None
+    client.cookies = None
     client.refresh_token = "test-refresh-token"
-    client.get_access_token = AsyncMock(
+    client.refreshed_cookies = None
+    client.get_access_token_from_refresh_token = AsyncMock(
         return_value=MagicMock(access_token="new-google-token")
     )
     client.authenticate = AsyncMock(return_value=new_session)
-
-    # After get_access_token is called, auth should be set
-    def set_auth(*args, **kwargs):
-        client.auth = MagicMock(access_token="new-google-token")
-        client.auth.is_expired = MagicMock(return_value=False)
-
-    client.get_access_token.side_effect = set_auth
+    client.get_first_data = AsyncMock(return_value=_make_first_data())
 
     store = MagicMock()
+    store.async_load = AsyncMock(return_value=None)
     store.async_save = AsyncMock()
 
     manager = NestSessionManager(client=client, store=store)
 
     await manager.ensure_session()
 
-    # Should have fetched a new Google token
-    client.get_access_token.assert_called_once()
+    client.get_access_token_from_refresh_token.assert_awaited_once_with(
+        "test-refresh-token"
+    )
     # Should have authenticated with the new Google token
     client.authenticate.assert_called_once_with("new-google-token")
     # Should have persisted the new session
-    store.async_save.assert_called_once()
+    store.async_save.assert_awaited()
+    assert store.async_save.await_args.args[0]["nest_session"] == new_session.to_dict()
     # Should have set the new session on the client
     assert client.nest_session == new_session
-
-
-@pytest.mark.asyncio
-async def test_record_failure_increments_counter():
-    """record_failure increments the consecutive failure counter."""
-    client = MagicMock()
-    store = MagicMock()
-
-    manager = NestSessionManager(client=client, store=store)
-
-    assert manager.consecutive_failures == 0
-    manager.record_failure()
-    assert manager.consecutive_failures == 1
-    manager.record_failure()
-    assert manager.consecutive_failures == 2
-
-
-@pytest.mark.asyncio
-async def test_record_success_resets_counter():
-    """record_success resets the failure counter."""
-    client = MagicMock()
-    store = MagicMock()
-
-    manager = NestSessionManager(client=client, store=store)
-
-    manager.record_failure()
-    manager.record_failure()
-    assert manager.consecutive_failures == 2
-
-    manager.record_success()
-    assert manager.consecutive_failures == 0
-
-
-@pytest.mark.asyncio
-async def test_should_reauth_after_max_failures():
-    """should_trigger_reauth returns True after MAX_AUTH_FAILURES."""
-    client = MagicMock()
-    store = MagicMock()
-
-    manager = NestSessionManager(client=client, store=store)
-
-    # Should be False initially
-    assert manager.should_trigger_reauth is False
-
-    # Record failures up to threshold
-    for _ in range(MAX_AUTH_FAILURES - 1):
-        manager.record_failure()
-    assert manager.should_trigger_reauth is False
-
-    # One more failure should trigger reauth
-    manager.record_failure()
-    assert manager.should_trigger_reauth is True
-
-
-@pytest.mark.asyncio
-async def test_backoff_interval_increases():
-    """backoff_interval returns increasing values."""
-    client = MagicMock()
-    store = MagicMock()
-
-    manager = NestSessionManager(client=client, store=store)
-
-    # At 0 failures, should return the first interval
-    assert manager.backoff_interval == BACKOFF_INTERVALS[0]
-
-    # Each failure should increase the backoff
-    manager.record_failure()
-    assert manager.backoff_interval == BACKOFF_INTERVALS[0]
-
-    manager.record_failure()
-    assert manager.backoff_interval == BACKOFF_INTERVALS[1]
-
-    manager.record_failure()
-    assert manager.backoff_interval == BACKOFF_INTERVALS[2]
-
-    # Should cap at the last interval
-    for _ in range(10):
-        manager.record_failure()
-    assert manager.backoff_interval == BACKOFF_INTERVALS[-1]


### PR DESCRIPTION
## Summary

- centralize Google and Nest authentication in a serialized, provider-neutral session coordinator
- persist refreshed credentials and reauthentication handoffs before dependent requests continue
- retain legacy refresh-token authentication while making future credential providers pluggable
- classify authentication rejection separately from transient transport and service failures
- add bounded full-provider retries plus restart, rotation, fallback, and concurrency regressions

## Authentication behavior

Authentication runs immediately and then retries explicit rejection after 1, 5, and 30 seconds. Each attempt tries every available credential provider through complete Nest session validation. Transient network, rate-limit, and service failures do not trigger reauthentication.

## Verification

- 205 tests passed
- Ruff check passed
- Ruff format check passed
- git diff --check passed
- commit hooks passed

## Scope boundary

Google-revoked or device-bound credentials still require genuinely new credentials; the integration now handles the restart, persistence, provider fallback, and concurrency failures within its control.