### PR TITLE
Refresh Google credentials on their own cadence, not the Nest session's

### DIFF
--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -104,6 +104,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     session_manager = NestSessionManager(client=client, store=store)
 
+    def _on_credentials_refreshed() -> None:
+        """Persist cookies Google rotated during any credential refresh."""
+        _persist_refreshed_cookies(hass, entry, client, session_manager)
+
+    # Covers refreshes triggered from entity updates too, which reach the
+    # session manager directly and have no persistence step of their own.
+    session_manager.on_credentials_refreshed = _on_credentials_refreshed
+
     try:
         data = await session_manager.async_setup()
     except (TimeoutError, ClientError) as exception:

--- a/custom_components/nest_protect/const.py
+++ b/custom_components/nest_protect/const.py
@@ -29,5 +29,8 @@ PLATFORMS: list[Platform] = [
 STORAGE_VERSION: Final = 1
 STORAGE_KEY_FORMAT: Final = "nest_protect_{entry_id}"
 SESSION_EXPIRY_BUFFER_SECONDS: Final = 300  # 5 minutes
+# How often the Google credentials are re-exercised to keep the auth cookies
+# from going stale. Matches the lifetime of a Google access token.
+GOOGLE_REFRESH_INTERVAL_SECONDS: Final = 3600  # 1 hour
 MAX_AUTH_FAILURES: Final = 3
 BACKOFF_INTERVALS: Final = (30, 60, 120, 300, 600)  # seconds, capped at 10 min

--- a/custom_components/nest_protect/pynest/client.py
+++ b/custom_components/nest_protect/pynest/client.py
@@ -113,10 +113,15 @@ class NestClient:
     async def get_access_token(self) -> GoogleAuthResponse:
         """Get a Nest access token."""
 
-        if self.refresh_token:
-            await self.get_access_token_from_refresh_token(self.refresh_token)
-        elif self.issue_token and self.cookies:
+        # Cookies first, matching the order the session manager authenticates
+        # in. A re-authenticated entry keeps any legacy refresh_token
+        # alongside the new cookies, and preferring it here would refresh a
+        # stale credential while the cookies — which do need refreshing to
+        # stay valid — were never exercised.
+        if self.issue_token and self.cookies:
             await self.get_access_token_from_cookies(self.issue_token, self.cookies)
+        elif self.refresh_token:
+            await self.get_access_token_from_refresh_token(self.refresh_token)
 
         return self.auth
 

--- a/custom_components/nest_protect/session.py
+++ b/custom_components/nest_protect/session.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
+from collections.abc import Callable
 
 from homeassistant.helpers.storage import Store
 
@@ -37,6 +39,12 @@ class NestSessionManager:
         self._store = store
         self._consecutive_failures: int = 0
         self._google_refreshed_at: float = 0.0
+        self._google_refresh_lock = asyncio.Lock()
+
+        # Invoked after Google credentials are refreshed, so the caller can
+        # persist the cookies Google rotated during it. Every refresh path
+        # runs through here, which the individual call sites did not.
+        self.on_credentials_refreshed: Callable[[], None] | None = None
 
     @property
     def refreshed_cookies(self) -> str | None:
@@ -91,10 +99,8 @@ class NestSessionManager:
         if not persisted or not persisted.get("nest_session"):
             return None
 
-        # A store written before this key existed says nothing about how stale
-        # the cookies are; treat it as fresh so the existing "skip Google
-        # entirely" startup path is preserved. The next hourly check refreshes.
-        self._google_refreshed_at = persisted.get("google_refreshed_at") or time.time()
+        stored_refreshed_at = persisted.get("google_refreshed_at")
+        self._google_refreshed_at = self._coerce_refresh_time(stored_refreshed_at)
 
         restored_session = NestResponse.from_dict(persisted["nest_session"])
 
@@ -114,7 +120,7 @@ class NestSessionManager:
 
         # Validate the session is actually accepted by Nest
         try:
-            return await self._client.get_first_data(
+            first_data = await self._client.get_first_data(
                 restored_session.access_token, restored_session.userid
             )
         except (NotAuthenticatedException, PynestException):  # fmt: skip
@@ -123,6 +129,14 @@ class NestSessionManager:
             )
             self._client.nest_session = None
             return None
+
+        if stored_refreshed_at != self._google_refreshed_at:
+            # Write the assumed clock straight back, otherwise every restart
+            # would assume "fresh" again and could postpone the refresh
+            # indefinitely on a frequently restarted instance.
+            await self._async_persist(restored_session)
+
+        return first_data
 
     async def _async_authenticate_and_fetch(self) -> FirstDataAPIResponse | None:
         """Authenticate with credentials and fetch first data.
@@ -162,7 +176,25 @@ class NestSessionManager:
 
         return await self._client.authenticate(auth.access_token)
 
-    async def ensure_google_credentials(self, *, force: bool = False) -> None:
+    @staticmethod
+    def _coerce_refresh_time(value: object) -> float:
+        """Normalise a persisted refresh timestamp into a usable value."""
+        now = time.time()
+
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            # Missing (store predates this key) or corrupt. Assume the cookies
+            # are fresh so the "skip Google entirely" startup path survives;
+            # the caller writes this assumption back to make it durable.
+            return now
+
+        if value > now:
+            # A future timestamp — clock skew or a corrupt store — must not
+            # suppress the refresh until the wall clock catches up.
+            return now
+
+        return float(value)
+
+    async def ensure_google_credentials(self, *, force: bool = False) -> bool:
         """Refresh the Google access token when it is due.
 
         Deliberately independent of Nest session validity. Google rotates the
@@ -174,43 +206,61 @@ class NestSessionManager:
         (USER_LOGGED_OUT) the next time they are presented.
 
         The last refresh time is persisted, so a restart does not reset the
-        clock and a still-valid persisted session can keep skipping Google.
-        Pass force to bypass that interval when recovering from a rejection.
+        clock. force skips that interval but still reuses a valid in-memory
+        token; it is for the paths recovering from a rejected session.
+
+        Returns True when the credentials were actually refreshed.
         """
-        if self._client.auth:
-            if not self._client.auth.is_expired():
-                return
-        elif (
-            not force
-            and (time.time() - self._google_refreshed_at)
-            < GOOGLE_REFRESH_INTERVAL_SECONDS
-        ):
-            # No token in memory yet, but the cookies were exercised recently
-            # enough that a restored session can keep skipping Google.
-            return
+        # Serialised: the subscriber, entities and the lock observer share one
+        # manager, and concurrent refreshes would each rotate the cookies while
+        # only the last response survives — losing the cookie Google expects.
+        async with self._google_refresh_lock:
+            if self._client.auth:
+                if not self._client.auth.is_expired():
+                    return False
+            elif (
+                not force
+                and (time.time() - self._google_refreshed_at)
+                < GOOGLE_REFRESH_INTERVAL_SECONDS
+            ):
+                # No token in memory yet, but the cookies were exercised
+                # recently enough for a restored session to keep skipping
+                # Google.
+                return False
 
-        LOGGER.debug("Retrieving new Google access token")
-        await self._client.get_access_token()
-        self._google_refreshed_at = time.time()
+            LOGGER.debug("Retrieving new Google access token")
+            await self._client.get_access_token()
 
-        # Record the new refresh time so a restart doesn't reset the clock.
-        # Only possible once there is a session to persist alongside it.
-        if self._client.nest_session:
-            await self._async_persist(self._client.nest_session)
+            if not self._client.auth:
+                # No usable credentials — don't record a refresh that the
+                # cookies never actually went through.
+                return False
+
+            self._google_refreshed_at = time.time()
+
+        if self.on_credentials_refreshed:
+            self.on_credentials_refreshed()
+
+        return True
 
     async def ensure_session(self) -> None:
         """Ensure valid Google credentials and a valid Nest session."""
+        nest_session_valid = self._client.nest_session is not None and not (
+            self._client.nest_session.is_expired(
+                buffer_seconds=SESSION_EXPIRY_BUFFER_SECONDS
+            )
+        )
+
         # Keep the Google cookies warm even while the Nest session is still
         # valid — Nest issues sessions lasting weeks, far longer than Google
         # honours a given cookie set.
-        await self.ensure_google_credentials()
+        refreshed = await self.ensure_google_credentials()
 
-        if self._client.nest_session and not self._client.nest_session.is_expired(
-            buffer_seconds=SESSION_EXPIRY_BUFFER_SECONDS
-        ):
-            return
-
-        await self.async_refresh_session()
+        if not nest_session_valid:
+            # Persists the session and the refresh clock together.
+            await self.async_refresh_session()
+        elif refreshed:
+            await self._async_persist(self._client.nest_session)
 
     async def async_refresh_session(self) -> bool:
         """Force-refresh the Nest session via Google credentials.

--- a/custom_components/nest_protect/session.py
+++ b/custom_components/nest_protect/session.py
@@ -39,7 +39,7 @@ class NestSessionManager:
         self._store = store
         self._consecutive_failures: int = 0
         self._google_refreshed_at: float = 0.0
-        self._google_refresh_lock = asyncio.Lock()
+        self._refresh_lock = asyncio.Lock()
 
         # Invoked after Google credentials are refreshed, so the caller can
         # persist the cookies Google rotated during it. Every refresh path
@@ -174,6 +174,12 @@ class NestSessionManager:
 
         self._google_refreshed_at = time.time()
 
+        # Notify before authenticating against Nest, not after async_setup()
+        # returns: Google has already rotated the cookies by this point, and if
+        # the Nest call below fails the retry must not start from the
+        # superseded set.
+        self._notify_credentials_refreshed(True)
+
         return await self._client.authenticate(auth.access_token)
 
     @staticmethod
@@ -211,64 +217,91 @@ class NestSessionManager:
 
         Returns True when the credentials were actually refreshed.
         """
-        # Serialised: the subscriber, entities and the lock observer share one
-        # manager, and concurrent refreshes would each rotate the cookies while
-        # only the last response survives — losing the cookie Google expects.
-        async with self._google_refresh_lock:
-            if self._client.auth:
-                if not self._client.auth.is_expired():
-                    return False
-            elif (
-                not force
-                and (time.time() - self._google_refreshed_at)
-                < GOOGLE_REFRESH_INTERVAL_SECONDS
-            ):
-                # No token in memory yet, but the cookies were exercised
-                # recently enough for a restored session to keep skipping
-                # Google.
+        async with self._refresh_lock:
+            refreshed = await self._async_refresh_google_credentials(force=force)
+
+        self._notify_credentials_refreshed(refreshed)
+
+        return refreshed
+
+    async def _async_refresh_google_credentials(self, *, force: bool) -> bool:
+        """Refresh the Google access token. Caller must hold the lock."""
+        if self._client.auth:
+            if not self._client.auth.is_expired():
                 return False
+        elif (
+            not force
+            and (time.time() - self._google_refreshed_at)
+            < GOOGLE_REFRESH_INTERVAL_SECONDS
+        ):
+            # No token in memory yet, but the cookies were exercised recently
+            # enough for a restored session to keep skipping Google.
+            return False
 
-            LOGGER.debug("Retrieving new Google access token")
-            await self._client.get_access_token()
+        LOGGER.debug("Retrieving new Google access token")
+        await self._client.get_access_token()
 
-            if not self._client.auth:
-                # No usable credentials — don't record a refresh that the
-                # cookies never actually went through.
-                return False
+        if not self._client.auth or self._client.auth.is_expired():
+            # No usable token came back — don't record a refresh that the
+            # cookies never actually went through.
+            return False
 
-            self._google_refreshed_at = time.time()
-
-        if self.on_credentials_refreshed:
-            self.on_credentials_refreshed()
+        self._google_refreshed_at = time.time()
 
         return True
 
+    def _notify_credentials_refreshed(self, refreshed: bool) -> None:
+        """Let the caller persist cookies Google rotated during a refresh.
+
+        Called outside the lock: the callback reaches into Home Assistant to
+        update the config entry and has no business holding up other refreshes.
+        """
+        if refreshed and self.on_credentials_refreshed:
+            self.on_credentials_refreshed()
+
     async def ensure_session(self) -> None:
         """Ensure valid Google credentials and a valid Nest session."""
-        nest_session_valid = self._client.nest_session is not None and not (
-            self._client.nest_session.is_expired(
-                buffer_seconds=SESSION_EXPIRY_BUFFER_SECONDS
+        # Serialised as a whole: the subscriber, entities and the lock observer
+        # share one manager. Concurrent refreshes would each rotate the cookies
+        # while only the last response survives — losing the value Google now
+        # expects — and would authenticate against Nest twice over.
+        async with self._refresh_lock:
+            # Keep the Google cookies warm even while the Nest session is still
+            # valid — Nest issues sessions lasting weeks, far longer than
+            # Google honours a given cookie set.
+            refreshed = await self._async_refresh_google_credentials(force=False)
+
+            # Re-read validity now the lock is held: a caller that waited here
+            # may find the session it was about to replace already renewed.
+            nest_session_valid = self._client.nest_session is not None and not (
+                self._client.nest_session.is_expired(
+                    buffer_seconds=SESSION_EXPIRY_BUFFER_SECONDS
+                )
             )
-        )
 
-        # Keep the Google cookies warm even while the Nest session is still
-        # valid — Nest issues sessions lasting weeks, far longer than Google
-        # honours a given cookie set.
-        refreshed = await self.ensure_google_credentials()
+            if not nest_session_valid:
+                # Persists the session and the refresh clock together.
+                await self._async_refresh_nest_session()
+            elif refreshed:
+                await self._async_persist(self._client.nest_session)
 
-        if not nest_session_valid:
-            # Persists the session and the refresh clock together.
-            await self.async_refresh_session()
-        elif refreshed:
-            await self._async_persist(self._client.nest_session)
+        self._notify_credentials_refreshed(refreshed)
 
     async def async_refresh_session(self) -> bool:
         """Force-refresh the Nest session via Google credentials.
 
         Returns True when a fresh Nest session was obtained and persisted.
         """
-        await self.ensure_google_credentials(force=True)
+        async with self._refresh_lock:
+            refreshed = await self._async_refresh_google_credentials(force=True)
+            renewed = await self._async_refresh_nest_session()
 
+        self._notify_credentials_refreshed(refreshed)
+
+        return renewed
+
+    async def _async_refresh_nest_session(self) -> bool:
+        """Re-authenticate against Nest and persist. Caller must hold the lock."""
         if not self._client.auth:
             return False
 

--- a/custom_components/nest_protect/session.py
+++ b/custom_components/nest_protect/session.py
@@ -162,9 +162,16 @@ class NestSessionManager:
         Raises authentication exceptions from the underlying client on failure.
         """
         if self._client.issue_token and self._client.cookies:
-            auth = await self._client.get_access_token_from_cookies(
-                self._client.issue_token, self._client.cookies
-            )
+            try:
+                auth = await self._client.get_access_token_from_cookies(
+                    self._client.issue_token, self._client.cookies
+                )
+            finally:
+                # Notify here rather than after async_setup() returns: Google
+                # may already have rotated the cookies, even if the request
+                # then failed, and a retry must not start from the superseded
+                # set.
+                self._notify_credentials_refreshed()
         elif self._client.refresh_token:
             auth = await self._client.get_access_token_from_refresh_token(
                 self._client.refresh_token
@@ -173,12 +180,6 @@ class NestSessionManager:
             return None
 
         self._google_refreshed_at = time.time()
-
-        # Notify before authenticating against Nest, not after async_setup()
-        # returns: Google has already rotated the cookies by this point, and if
-        # the Nest call below fails the retry must not start from the
-        # superseded set.
-        self._notify_credentials_refreshed(True)
 
         return await self._client.authenticate(auth.access_token)
 
@@ -217,12 +218,11 @@ class NestSessionManager:
 
         Returns True when the credentials were actually refreshed.
         """
-        async with self._refresh_lock:
-            refreshed = await self._async_refresh_google_credentials(force=force)
-
-        self._notify_credentials_refreshed(refreshed)
-
-        return refreshed
+        try:
+            async with self._refresh_lock:
+                return await self._async_refresh_google_credentials(force=force)
+        finally:
+            self._notify_credentials_refreshed()
 
     async def _async_refresh_google_credentials(self, *, force: bool) -> bool:
         """Refresh the Google access token. Caller must hold the lock."""
@@ -253,15 +253,19 @@ class NestSessionManager:
 
         return True
 
-    def _notify_credentials_refreshed(self, refreshed: bool) -> None:
+    def _notify_credentials_refreshed(self) -> None:
         """Let the caller persist cookies Google rotated during a refresh.
 
-        Called outside the lock, and from a finally block: the callback reaches
-        into Home Assistant to update the config entry, so it has no business
-        holding up other refreshes — and once Google has rotated the cookies a
-        later failure must not strand the superseded set in the config entry.
+        Keyed on the cookies actually captured rather than on the token
+        request succeeding: the client applies Set-Cookie before it reads the
+        response body, so a body that fails or is cancelled still leaves the
+        rotated set authoritative and the superseded one unusable.
+
+        Called outside the lock, and from a finally block — the callback
+        reaches into Home Assistant to update the config entry, so it has no
+        business holding up other refreshes.
         """
-        if refreshed and self.on_credentials_refreshed:
+        if self._client.refreshed_cookies and self.on_credentials_refreshed:
             self.on_credentials_refreshed()
 
     async def ensure_session(self) -> None:
@@ -293,20 +297,19 @@ class NestSessionManager:
                 elif refreshed:
                     await self._async_persist(self._client.nest_session)
         finally:
-            self._notify_credentials_refreshed(refreshed)
+            self._notify_credentials_refreshed()
 
     async def async_refresh_session(self) -> bool:
         """Force-refresh the Nest session via Google credentials.
 
         Returns True when a fresh Nest session was obtained and persisted.
         """
-        refreshed = False
         try:
             async with self._refresh_lock:
-                refreshed = await self._async_refresh_google_credentials(force=True)
+                await self._async_refresh_google_credentials(force=True)
                 return await self._async_refresh_nest_session()
         finally:
-            self._notify_credentials_refreshed(refreshed)
+            self._notify_credentials_refreshed()
 
     async def _async_refresh_nest_session(self) -> bool:
         """Re-authenticate against Nest and persist. Caller must hold the lock."""

--- a/custom_components/nest_protect/session.py
+++ b/custom_components/nest_protect/session.py
@@ -212,9 +212,11 @@ class NestSessionManager:
         which point Google has moved on and invalidates the session
         (USER_LOGGED_OUT) the next time they are presented.
 
-        The last refresh time is persisted, so a restart does not reset the
-        clock. force skips that interval but still reuses a valid in-memory
-        token; it is for the paths recovering from a rejected session.
+        Records the refresh time in memory; ensure_session() and
+        async_refresh_session() are what write it to the store alongside the
+        Nest session. force skips the interval but still reuses a valid
+        in-memory token; it is for the paths recovering from a rejected
+        session.
 
         Returns True when the credentials were actually refreshed.
         """

--- a/custom_components/nest_protect/session.py
+++ b/custom_components/nest_protect/session.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import time
+
 from homeassistant.helpers.storage import Store
 
 from .const import (
     BACKOFF_INTERVALS,
+    GOOGLE_REFRESH_INTERVAL_SECONDS,
     LOGGER,
     MAX_AUTH_FAILURES,
     SESSION_EXPIRY_BUFFER_SECONDS,
@@ -33,6 +36,7 @@ class NestSessionManager:
         self._client = client
         self._store = store
         self._consecutive_failures: int = 0
+        self._google_refreshed_at: float = 0.0
 
     @property
     def refreshed_cookies(self) -> str | None:
@@ -86,6 +90,11 @@ class NestSessionManager:
 
         if not persisted or not persisted.get("nest_session"):
             return None
+
+        # A store written before this key existed says nothing about how stale
+        # the cookies are; treat it as fresh so the existing "skip Google
+        # entirely" startup path is preserved. The next hourly check refreshes.
+        self._google_refreshed_at = persisted.get("google_refreshed_at") or time.time()
 
         restored_session = NestResponse.from_dict(persisted["nest_session"])
 
@@ -149,10 +158,53 @@ class NestSessionManager:
         else:
             return None
 
+        self._google_refreshed_at = time.time()
+
         return await self._client.authenticate(auth.access_token)
 
+    async def ensure_google_credentials(self, *, force: bool = False) -> None:
+        """Refresh the Google access token when it is due.
+
+        Deliberately independent of Nest session validity. Google rotates the
+        auth cookies on every token refresh and only honours the previous
+        values for a limited grace window, so the stored cookies have to be
+        exercised on their own cadence. Gating this on the Nest session instead
+        leaves them untouched for that session's full lifetime — weeks — by
+        which point Google has moved on and invalidates the session
+        (USER_LOGGED_OUT) the next time they are presented.
+
+        The last refresh time is persisted, so a restart does not reset the
+        clock and a still-valid persisted session can keep skipping Google.
+        Pass force to bypass that interval when recovering from a rejection.
+        """
+        if self._client.auth:
+            if not self._client.auth.is_expired():
+                return
+        elif (
+            not force
+            and (time.time() - self._google_refreshed_at)
+            < GOOGLE_REFRESH_INTERVAL_SECONDS
+        ):
+            # No token in memory yet, but the cookies were exercised recently
+            # enough that a restored session can keep skipping Google.
+            return
+
+        LOGGER.debug("Retrieving new Google access token")
+        await self._client.get_access_token()
+        self._google_refreshed_at = time.time()
+
+        # Record the new refresh time so a restart doesn't reset the clock.
+        # Only possible once there is a session to persist alongside it.
+        if self._client.nest_session:
+            await self._async_persist(self._client.nest_session)
+
     async def ensure_session(self) -> None:
-        """Ensure a valid Nest session exists, refreshing if needed."""
+        """Ensure valid Google credentials and a valid Nest session."""
+        # Keep the Google cookies warm even while the Nest session is still
+        # valid — Nest issues sessions lasting weeks, far longer than Google
+        # honours a given cookie set.
+        await self.ensure_google_credentials()
+
         if self._client.nest_session and not self._client.nest_session.is_expired(
             buffer_seconds=SESSION_EXPIRY_BUFFER_SECONDS
         ):
@@ -165,9 +217,7 @@ class NestSessionManager:
 
         Returns True when a fresh Nest session was obtained and persisted.
         """
-        if not self._client.auth or self._client.auth.is_expired():
-            LOGGER.debug("Retrieving new Google access token")
-            await self._client.get_access_token()
+        await self.ensure_google_credentials(force=True)
 
         if not self._client.auth:
             return False
@@ -184,5 +234,6 @@ class NestSessionManager:
             {
                 "nest_session": nest_session.to_dict(),
                 "transport_url": self._client.transport_url,
+                "google_refreshed_at": self._google_refreshed_at,
             }
         )

--- a/custom_components/nest_protect/session.py
+++ b/custom_components/nest_protect/session.py
@@ -231,11 +231,14 @@ class NestSessionManager:
                 return False
         elif (
             not force
-            and (time.time() - self._google_refreshed_at)
+            and 0
+            <= (time.time() - self._google_refreshed_at)
             < GOOGLE_REFRESH_INTERVAL_SECONDS
         ):
             # No token in memory yet, but the cookies were exercised recently
-            # enough for a restored session to keep skipping Google.
+            # enough for a restored session to keep skipping Google. A negative
+            # elapsed time means the clock went backwards, which must not
+            # suppress the refresh until it catches up.
             return False
 
         LOGGER.debug("Retrieving new Google access token")
@@ -253,52 +256,57 @@ class NestSessionManager:
     def _notify_credentials_refreshed(self, refreshed: bool) -> None:
         """Let the caller persist cookies Google rotated during a refresh.
 
-        Called outside the lock: the callback reaches into Home Assistant to
-        update the config entry and has no business holding up other refreshes.
+        Called outside the lock, and from a finally block: the callback reaches
+        into Home Assistant to update the config entry, so it has no business
+        holding up other refreshes — and once Google has rotated the cookies a
+        later failure must not strand the superseded set in the config entry.
         """
         if refreshed and self.on_credentials_refreshed:
             self.on_credentials_refreshed()
 
     async def ensure_session(self) -> None:
         """Ensure valid Google credentials and a valid Nest session."""
-        # Serialised as a whole: the subscriber, entities and the lock observer
-        # share one manager. Concurrent refreshes would each rotate the cookies
-        # while only the last response survives — losing the value Google now
-        # expects — and would authenticate against Nest twice over.
-        async with self._refresh_lock:
-            # Keep the Google cookies warm even while the Nest session is still
-            # valid — Nest issues sessions lasting weeks, far longer than
-            # Google honours a given cookie set.
-            refreshed = await self._async_refresh_google_credentials(force=False)
+        refreshed = False
+        try:
+            # Serialised as a whole: the subscriber, entities and the lock
+            # observer share one manager. Concurrent refreshes would each
+            # rotate the cookies while only the last response survives —
+            # losing the value Google now expects — and would authenticate
+            # against Nest twice over.
+            async with self._refresh_lock:
+                # Keep the Google cookies warm even while the Nest session is
+                # still valid — Nest issues sessions lasting weeks, far longer
+                # than Google honours a given cookie set.
+                refreshed = await self._async_refresh_google_credentials(force=False)
 
-            # Re-read validity now the lock is held: a caller that waited here
-            # may find the session it was about to replace already renewed.
-            nest_session_valid = self._client.nest_session is not None and not (
-                self._client.nest_session.is_expired(
-                    buffer_seconds=SESSION_EXPIRY_BUFFER_SECONDS
+                # Re-read validity now the lock is held: a caller that waited
+                # here may find the session it was about to replace renewed.
+                nest_session_valid = self._client.nest_session is not None and not (
+                    self._client.nest_session.is_expired(
+                        buffer_seconds=SESSION_EXPIRY_BUFFER_SECONDS
+                    )
                 )
-            )
 
-            if not nest_session_valid:
-                # Persists the session and the refresh clock together.
-                await self._async_refresh_nest_session()
-            elif refreshed:
-                await self._async_persist(self._client.nest_session)
-
-        self._notify_credentials_refreshed(refreshed)
+                if not nest_session_valid:
+                    # Persists the session and the refresh clock together.
+                    await self._async_refresh_nest_session()
+                elif refreshed:
+                    await self._async_persist(self._client.nest_session)
+        finally:
+            self._notify_credentials_refreshed(refreshed)
 
     async def async_refresh_session(self) -> bool:
         """Force-refresh the Nest session via Google credentials.
 
         Returns True when a fresh Nest session was obtained and persisted.
         """
-        async with self._refresh_lock:
-            refreshed = await self._async_refresh_google_credentials(force=True)
-            renewed = await self._async_refresh_nest_session()
-
-        self._notify_credentials_refreshed(refreshed)
-
-        return renewed
+        refreshed = False
+        try:
+            async with self._refresh_lock:
+                refreshed = await self._async_refresh_google_credentials(force=True)
+                return await self._async_refresh_nest_session()
+        finally:
+            self._notify_credentials_refreshed(refreshed)
 
     async def _async_refresh_nest_session(self) -> bool:
         """Re-authenticate against Nest and persist. Caller must hold the lock."""

--- a/tests/pynest/test_client.py
+++ b/tests/pynest/test_client.py
@@ -211,3 +211,45 @@ def test_merge_cookies_empty_new():
     original = "SID=old; HSID=val"
     result = merge_cookies(original, {})
     assert result == original
+
+
+async def test_get_access_token_prefers_cookies_over_legacy_refresh_token():
+    """Cookies win when a re-authenticated entry still carries a refresh token.
+
+    Regression test: preferring the refresh token meant the cookies were never
+    exercised, so they went stale and Google eventually rejected the session.
+    """
+    nest_client = NestClient(session=None)
+    nest_client.issue_token = "https://accounts.google.com/o/oauth2/iframerpc"
+    nest_client.cookies = "SID=current"
+    nest_client.refresh_token = "obsolete-legacy-token"
+
+    with (
+        patch.object(NestClient, "get_access_token_from_cookies") as mock_cookie_auth,
+        patch.object(
+            NestClient, "get_access_token_from_refresh_token"
+        ) as mock_token_auth,
+    ):
+        await nest_client.get_access_token()
+
+    mock_cookie_auth.assert_called_once()
+    mock_token_auth.assert_not_called()
+
+
+async def test_get_access_token_falls_back_to_refresh_token():
+    """Entries with only a refresh token keep using it."""
+    nest_client = NestClient(session=None)
+    nest_client.issue_token = None
+    nest_client.cookies = None
+    nest_client.refresh_token = "legacy-token"
+
+    with (
+        patch.object(NestClient, "get_access_token_from_cookies") as mock_cookie_auth,
+        patch.object(
+            NestClient, "get_access_token_from_refresh_token"
+        ) as mock_token_auth,
+    ):
+        await nest_client.get_access_token()
+
+    mock_cookie_auth.assert_not_called()
+    mock_token_auth.assert_called_once()

--- a/tests/pynest/test_client.py
+++ b/tests/pynest/test_client.py
@@ -1,6 +1,6 @@
 """Tests for NestClient."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from aiohttp import ClientSession, web
@@ -219,7 +219,7 @@ async def test_get_access_token_prefers_cookies_over_legacy_refresh_token():
     Regression test: preferring the refresh token meant the cookies were never
     exercised, so they went stale and Google eventually rejected the session.
     """
-    nest_client = NestClient(session=None)
+    nest_client = NestClient(session=MagicMock())
     nest_client.issue_token = "https://accounts.google.com/o/oauth2/iframerpc"
     nest_client.cookies = "SID=current"
     nest_client.refresh_token = "obsolete-legacy-token"
@@ -238,7 +238,7 @@ async def test_get_access_token_prefers_cookies_over_legacy_refresh_token():
 
 async def test_get_access_token_falls_back_to_refresh_token():
     """Entries with only a refresh token keep using it."""
-    nest_client = NestClient(session=None)
+    nest_client = NestClient(session=MagicMock())
     nest_client.issue_token = None
     nest_client.cookies = None
     nest_client.refresh_token = "legacy-token"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -202,13 +203,128 @@ async def test_no_persisted_session_uses_cookies():
 
 
 @pytest.mark.asyncio
-async def test_ensure_session_valid():
-    """ensure_session is a no-op when session is still valid."""
+async def test_stale_persisted_refresh_time_rewarms_cookies_after_restart():
+    """A restored session whose cookies are overdue refreshes them immediately.
+
+    The refresh clock is persisted precisely so that restarting HA cannot keep
+    postponing the refresh indefinitely.
+    """
     valid_session = _make_nest_response(expired=False)
 
     client = MagicMock()
     client.nest_session = valid_session
     client.auth = None
+    client.issue_token = "https://accounts.google.com/issue"
+    client.cookies = "SID=test"
+    client.refresh_token = None
+    client.transport_url = None
+    client.get_access_token = AsyncMock()
+    client.get_first_data = AsyncMock(return_value=_make_first_data())
+    client.authenticate = AsyncMock()
+
+    store = MagicMock()
+    store.async_save = AsyncMock()
+    store.async_load = AsyncMock(
+        return_value={
+            "nest_session": valid_session.to_dict(),
+            "transport_url": "https://transport.example.com",
+            # Last exercised two days ago — long past the refresh interval.
+            "google_refreshed_at": time.time() - 2 * 24 * 60 * 60,
+        }
+    )
+
+    manager = NestSessionManager(client=client, store=store)
+
+    await manager.async_setup()
+    client.get_access_token.assert_not_called()
+
+    await manager.ensure_session()
+
+    client.get_access_token.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_recent_persisted_refresh_time_skips_google_after_restart():
+    """A restored session whose cookies are still warm does not call Google."""
+    valid_session = _make_nest_response(expired=False)
+
+    client = MagicMock()
+    client.nest_session = valid_session
+    client.auth = None
+    client.transport_url = None
+    client.get_access_token = AsyncMock()
+    client.get_first_data = AsyncMock(return_value=_make_first_data())
+    client.authenticate = AsyncMock()
+
+    store = MagicMock()
+    store.async_save = AsyncMock()
+    store.async_load = AsyncMock(
+        return_value={
+            "nest_session": valid_session.to_dict(),
+            "transport_url": "https://transport.example.com",
+            "google_refreshed_at": time.time() - 60,
+        }
+    )
+
+    manager = NestSessionManager(client=client, store=store)
+
+    await manager.async_setup()
+    await manager.ensure_session()
+
+    client.get_access_token.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_forced_refresh_ignores_interval_after_restart():
+    """async_refresh_session always reaches Google, even inside the interval.
+
+    It is the 401 recovery path, so throttling it would leave a restored
+    session that Nest has rejected with no way back.
+    """
+    new_session = _make_nest_response(expired=False)
+
+    client = MagicMock()
+    client.nest_session = _make_nest_response(expired=False)
+    client.auth = None
+    client.transport_url = None
+    client.get_first_data = AsyncMock(return_value=_make_first_data())
+    client.authenticate = AsyncMock(return_value=new_session)
+
+    def set_auth(*args, **kwargs):
+        client.auth = MagicMock(access_token="new-google-token")
+        client.auth.is_expired = MagicMock(return_value=False)
+
+    client.get_access_token = AsyncMock(side_effect=set_auth)
+
+    store = MagicMock()
+    store.async_save = AsyncMock()
+    store.async_load = AsyncMock(
+        return_value={
+            "nest_session": client.nest_session.to_dict(),
+            "transport_url": "https://transport.example.com",
+            # Well inside the interval — ensure_session would skip Google here.
+            "google_refreshed_at": time.time() - 60,
+        }
+    )
+
+    manager = NestSessionManager(client=client, store=store)
+
+    await manager.async_setup()
+
+    assert await manager.async_refresh_session() is True
+    client.get_access_token.assert_called_once()
+    client.authenticate.assert_called_once_with("new-google-token")
+
+
+@pytest.mark.asyncio
+async def test_ensure_session_valid():
+    """ensure_session is a no-op when both the Nest and Google tokens are valid."""
+    valid_session = _make_nest_response(expired=False)
+
+    client = MagicMock()
+    client.nest_session = valid_session
+    client.auth = MagicMock(access_token="existing-google-token")
+    client.auth.is_expired = MagicMock(return_value=False)
     client.refresh_token = "test-refresh-token"
     client.get_access_token = AsyncMock()
     client.authenticate = AsyncMock()
@@ -224,6 +340,42 @@ async def test_ensure_session_valid():
     client.get_access_token.assert_not_called()
     client.authenticate.assert_not_called()
     store.async_save.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ensure_session_refreshes_google_token_while_nest_session_valid():
+    """An expired Google token is refreshed even while the Nest session is valid.
+
+    Regression test: Nest issues sessions lasting weeks, so gating the Google
+    refresh on Nest session expiry left the auth cookies untouched for that
+    whole period. Google rotates them on a far shorter cycle, so by the time
+    they were next used the session had been invalidated (USER_LOGGED_OUT),
+    forcing a re-authentication every day or two.
+    """
+    valid_session = _make_nest_response(expired=False)
+
+    client = MagicMock()
+    client.nest_session = valid_session
+    client.auth = MagicMock(access_token="stale-google-token")
+    client.auth.is_expired = MagicMock(return_value=True)
+    client.refresh_token = "test-refresh-token"
+    client.get_access_token = AsyncMock()
+    client.authenticate = AsyncMock()
+
+    store = MagicMock()
+    store.async_save = AsyncMock()
+
+    manager = NestSessionManager(client=client, store=store)
+
+    await manager.ensure_session()
+
+    # The Google token — and with it the cookies — must be refreshed.
+    client.get_access_token.assert_called_once()
+    # But the still-valid Nest session must not be needlessly replaced.
+    client.authenticate.assert_not_called()
+    # The refresh time is persisted so a restart doesn't reset the clock.
+    assert store.async_save.call_count == 1
+    assert store.async_save.call_args[0][0]["google_refreshed_at"] > 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -12,6 +12,7 @@ import pytest
 from custom_components.nest_protect.const import BACKOFF_INTERVALS, MAX_AUTH_FAILURES
 from custom_components.nest_protect.pynest.exceptions import (
     NotAuthenticatedException,
+    PynestException,
 )
 from custom_components.nest_protect.pynest.models import NestResponse
 from custom_components.nest_protect.session import NestSessionManager
@@ -360,8 +361,13 @@ async def test_ensure_session_refreshes_google_token_while_nest_session_valid():
     client.auth = MagicMock(access_token="stale-google-token")
     client.auth.is_expired = MagicMock(return_value=True)
     client.refresh_token = "test-refresh-token"
-    client.get_access_token = AsyncMock()
     client.authenticate = AsyncMock()
+
+    def issue_fresh_token(*args, **kwargs):
+        client.auth = MagicMock(access_token="fresh-google-token")
+        client.auth.is_expired = MagicMock(return_value=False)
+
+    client.get_access_token = AsyncMock(side_effect=issue_fresh_token)
 
     store = MagicMock()
     store.async_save = AsyncMock()
@@ -674,3 +680,93 @@ async def test_refresh_notifies_caller_to_persist_rotated_cookies():
     await manager.ensure_session()
 
     manager.on_credentials_refreshed.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_expired_session_coalesces_nest_authentication():
+    """The whole refresh is single-flight, not just the Google half.
+
+    Two callers finding an expired Nest session would otherwise authenticate
+    twice and write twice, and a reordered response could leave the client
+    holding the session Nest had already superseded.
+    """
+    fresh_session = _make_nest_response(expired=False)
+
+    client = MagicMock()
+    client.nest_session = _make_nest_response(expired=True)
+    client.auth = MagicMock(access_token="google-token")
+    client.auth.is_expired = MagicMock(return_value=False)
+    client.transport_url = None
+
+    async def authenticate(_token):
+        await asyncio.sleep(0)
+        return fresh_session
+
+    client.authenticate = AsyncMock(side_effect=authenticate)
+
+    store = MagicMock()
+    store.async_save = AsyncMock()
+
+    manager = NestSessionManager(client=client, store=store)
+
+    await asyncio.gather(manager.ensure_session(), manager.ensure_session())
+
+    assert client.authenticate.call_count == 1
+    assert store.async_save.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_startup_rotation_is_notified_before_nest_authentication():
+    """Cookies rotated at startup survive a later failure talking to Nest.
+
+    Google has already moved on by the time authenticate() runs, so a retry
+    starting from the superseded cookies would be rejected.
+    """
+    client = MagicMock()
+    client.nest_session = None
+    client.issue_token = "https://accounts.google.com/issue"
+    client.cookies = "SID=old"
+    client.refresh_token = None
+    client.transport_url = None
+
+    def rotate_cookies(*args, **kwargs):
+        client.refreshed_cookies = "SID=new"
+        client.cookies = "SID=new"
+        return MagicMock(access_token="google-token")
+
+    client.get_access_token_from_cookies = AsyncMock(side_effect=rotate_cookies)
+    client.authenticate = AsyncMock(side_effect=PynestException("Nest unavailable"))
+
+    store = MagicMock()
+    store.async_load = AsyncMock(return_value=None)
+    store.async_save = AsyncMock()
+
+    manager = NestSessionManager(client=client, store=store)
+    manager.on_credentials_refreshed = MagicMock()
+
+    with pytest.raises(PynestException):
+        await manager.async_setup()
+
+    manager.on_credentials_refreshed.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_unchanged_expired_token_is_not_reported_as_refreshed():
+    """A token request that changed nothing must not advance the clock."""
+    expired_auth = MagicMock(access_token="expired")
+    expired_auth.is_expired = MagicMock(return_value=True)
+
+    client = MagicMock()
+    client.nest_session = None
+    client.auth = expired_auth
+    client.get_access_token = AsyncMock(return_value=expired_auth)
+
+    store = MagicMock()
+    store.async_save = AsyncMock()
+
+    manager = NestSessionManager(client=client, store=store)
+    manager.on_credentials_refreshed = MagicMock()
+
+    assert await manager.ensure_google_credentials(force=True) is False
+    manager.on_credentials_refreshed.assert_not_called()
+    store.async_save.assert_not_called()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import datetime
 import time
 from unittest.mock import AsyncMock, MagicMock
@@ -521,3 +522,155 @@ async def test_backoff_interval_increases():
     for _ in range(10):
         manager.record_failure()
     assert manager.backoff_interval == BACKOFF_INTERVALS[-1]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_ensure_session_coalesces_google_refresh():
+    """Concurrent callers must not each rotate the cookies.
+
+    The subscriber, entities and the lock observer share one manager. Two
+    refreshes in flight would both rotate, and only the last response would be
+    kept — discarding the cookie Google now expects.
+    """
+    expired_auth = MagicMock(access_token="stale")
+    expired_auth.is_expired = MagicMock(return_value=True)
+
+    client = MagicMock()
+    client.nest_session = _make_nest_response(expired=False)
+    client.auth = expired_auth
+    client.transport_url = None
+    client.authenticate = AsyncMock()
+
+    async def refresh(*args, **kwargs):
+        await asyncio.sleep(0)
+        fresh = MagicMock(access_token="fresh")
+        fresh.is_expired = MagicMock(return_value=False)
+        client.auth = fresh
+
+    client.get_access_token = AsyncMock(side_effect=refresh)
+
+    store = MagicMock()
+    store.async_save = AsyncMock()
+
+    manager = NestSessionManager(client=client, store=store)
+
+    await asyncio.gather(manager.ensure_session(), manager.ensure_session())
+
+    client.get_access_token.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_missing_credentials_do_not_advance_refresh_clock():
+    """A refresh that produced no token must not count as one."""
+    client = MagicMock()
+    client.nest_session = _make_nest_response(expired=False)
+    client.auth = None
+    client.transport_url = None
+    client.get_access_token = AsyncMock(return_value=None)
+    client.authenticate = AsyncMock()
+
+    store = MagicMock()
+    store.async_save = AsyncMock()
+
+    manager = NestSessionManager(client=client, store=store)
+
+    assert await manager.ensure_google_credentials(force=True) is False
+    store.async_save.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_legacy_store_persists_assumed_refresh_clock():
+    """A store predating the clock writes the assumed value back.
+
+    Otherwise every restart would assume "fresh" again, letting a frequently
+    restarted instance postpone the refresh indefinitely.
+    """
+    valid_session = _make_nest_response(expired=False)
+
+    client = MagicMock()
+    client.nest_session = None
+    client.auth = None
+    client.transport_url = None
+    client.get_access_token = AsyncMock()
+    client.get_first_data = AsyncMock(return_value=_make_first_data())
+
+    store = MagicMock()
+    store.async_save = AsyncMock()
+    store.async_load = AsyncMock(
+        return_value={
+            "nest_session": valid_session.to_dict(),
+            "transport_url": "https://transport.example.com",
+        }
+    )
+
+    manager = NestSessionManager(client=client, store=store)
+
+    await manager.async_setup()
+
+    store.async_save.assert_called_once()
+    assert store.async_save.call_args[0][0]["google_refreshed_at"] > 0
+
+
+@pytest.mark.asyncio
+async def test_future_refresh_time_does_not_suppress_refresh():
+    """A corrupt or skewed future timestamp must not disable refreshing."""
+    valid_session = _make_nest_response(expired=False)
+
+    client = MagicMock()
+    client.nest_session = None
+    client.auth = None
+    client.transport_url = None
+    client.get_access_token = AsyncMock()
+    client.get_first_data = AsyncMock(return_value=_make_first_data())
+
+    store = MagicMock()
+    store.async_save = AsyncMock()
+    store.async_load = AsyncMock(
+        return_value={
+            "nest_session": valid_session.to_dict(),
+            "transport_url": "https://transport.example.com",
+            "google_refreshed_at": time.time() + 365 * 24 * 60 * 60,
+        }
+    )
+
+    manager = NestSessionManager(client=client, store=store)
+
+    await manager.async_setup()
+
+    # Clamped to now and written back, rather than trusted.
+    store.async_save.assert_called_once()
+    assert store.async_save.call_args[0][0]["google_refreshed_at"] <= time.time()
+
+
+@pytest.mark.asyncio
+async def test_refresh_notifies_caller_to_persist_rotated_cookies():
+    """Every refresh path reports back so rotated cookies can be persisted.
+
+    Entity updates refresh through the manager directly and have no
+    persistence step of their own.
+    """
+    expired_auth = MagicMock(access_token="stale")
+    expired_auth.is_expired = MagicMock(return_value=True)
+
+    client = MagicMock()
+    client.nest_session = _make_nest_response(expired=False)
+    client.auth = expired_auth
+    client.transport_url = None
+    client.authenticate = AsyncMock()
+
+    def refresh(*args, **kwargs):
+        fresh = MagicMock(access_token="fresh")
+        fresh.is_expired = MagicMock(return_value=False)
+        client.auth = fresh
+
+    client.get_access_token = AsyncMock(side_effect=refresh)
+
+    store = MagicMock()
+    store.async_save = AsyncMock()
+
+    manager = NestSessionManager(client=client, store=store)
+    manager.on_credentials_refreshed = MagicMock()
+
+    await manager.ensure_session()
+
+    manager.on_credentials_refreshed.assert_called_once()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -770,3 +770,98 @@ async def test_unchanged_expired_token_is_not_reported_as_refreshed():
     assert await manager.ensure_google_credentials(force=True) is False
     manager.on_credentials_refreshed.assert_not_called()
     store.async_save.assert_not_called()
+
+
+def _rotation_then_nest_failure_manager():
+    """Build a manager whose Google refresh succeeds but Nest then fails."""
+    stale_auth = MagicMock(access_token="stale")
+    stale_auth.is_expired = MagicMock(return_value=True)
+
+    client = MagicMock()
+    client.auth = stale_auth
+    client.nest_session = _make_nest_response(expired=True)
+    client.transport_url = None
+
+    async def rotate_credentials():
+        fresh_auth = MagicMock(access_token="fresh")
+        fresh_auth.is_expired = MagicMock(return_value=False)
+        client.auth = fresh_auth
+        client.refreshed_cookies = "SID=new"
+
+    client.get_access_token = AsyncMock(side_effect=rotate_credentials)
+    client.authenticate = AsyncMock(side_effect=PynestException("Nest unavailable"))
+
+    store = MagicMock()
+    store.async_save = AsyncMock()
+
+    manager = NestSessionManager(client=client, store=store)
+    manager.on_credentials_refreshed = MagicMock()
+    return manager, client
+
+
+@pytest.mark.asyncio
+async def test_ensure_session_notifies_rotation_when_nest_auth_fails():
+    """Cookies rotated before a Nest failure still reach the config entry.
+
+    Otherwise the in-memory client holds the new cookies while the entry keeps
+    the superseded set, and a restart reproduces the very USER_LOGGED_OUT this
+    is meant to prevent.
+    """
+    manager, _client = _rotation_then_nest_failure_manager()
+
+    with pytest.raises(PynestException):
+        await manager.ensure_session()
+
+    manager.on_credentials_refreshed.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_forced_refresh_notifies_rotation_when_nest_auth_fails():
+    """Same guarantee on the 401 recovery path."""
+    manager, _client = _rotation_then_nest_failure_manager()
+
+    with pytest.raises(PynestException):
+        await manager.async_refresh_session()
+
+    manager.on_credentials_refreshed.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_refresh_lock_is_released_after_nest_auth_failure():
+    """A failed refresh must not strand the lock and wedge every later one."""
+    manager, client = _rotation_then_nest_failure_manager()
+
+    with pytest.raises(PynestException):
+        await manager.async_refresh_session()
+
+    client.authenticate = AsyncMock(return_value=_make_nest_response(expired=False))
+
+    assert await asyncio.wait_for(manager.async_refresh_session(), timeout=1) is True
+
+
+@pytest.mark.asyncio
+async def test_clock_rollback_does_not_suppress_due_refresh():
+    """A backwards system clock must not park the refresh indefinitely."""
+    client = MagicMock()
+    client.auth = None
+    client.nest_session = _make_nest_response(expired=False)
+    client.transport_url = None
+
+    async def refresh_credentials():
+        fresh_auth = MagicMock(access_token="fresh")
+        fresh_auth.is_expired = MagicMock(return_value=False)
+        client.auth = fresh_auth
+
+    client.get_access_token = AsyncMock(side_effect=refresh_credentials)
+    client.authenticate = AsyncMock()
+
+    store = MagicMock()
+    store.async_save = AsyncMock()
+
+    manager = NestSessionManager(client=client, store=store)
+    # Recorded before the clock jumped backwards.
+    manager._google_refreshed_at = time.time() + 10_000
+
+    await manager.ensure_session()
+
+    client.get_access_token.assert_called_once()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import asyncio
 import datetime
 import time
+from http.cookies import SimpleCookie
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from custom_components.nest_protect.const import BACKOFF_INTERVALS, MAX_AUTH_FAILURES
+from custom_components.nest_protect.pynest.client import NestClient
 from custom_components.nest_protect.pynest.exceptions import (
     NotAuthenticatedException,
     PynestException,
@@ -572,6 +574,7 @@ async def test_missing_credentials_do_not_advance_refresh_clock():
     client.nest_session = _make_nest_response(expired=False)
     client.auth = None
     client.transport_url = None
+    client.refreshed_cookies = None
     client.get_access_token = AsyncMock(return_value=None)
     client.authenticate = AsyncMock()
 
@@ -759,6 +762,7 @@ async def test_unchanged_expired_token_is_not_reported_as_refreshed():
     client = MagicMock()
     client.nest_session = None
     client.auth = expired_auth
+    client.refreshed_cookies = None
     client.get_access_token = AsyncMock(return_value=expired_auth)
 
     store = MagicMock()
@@ -865,3 +869,51 @@ async def test_clock_rollback_does_not_suppress_due_refresh():
     await manager.ensure_session()
 
     client.get_access_token.assert_called_once()
+
+
+class _RotatingThenFailingResponse:
+    """Google response that rotates cookies before the body read fails."""
+
+    def __init__(self) -> None:
+        self.cookies = SimpleCookie()
+        self.cookies["SID"] = "new"
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    async def json(self):
+        raise PynestException("connection dropped reading the body")
+
+
+class _RotatingThenFailingSession:
+    """Minimal ClientSession stand-in returning the response above."""
+
+    def get(self, *args, **kwargs):
+        return _RotatingThenFailingResponse()
+
+
+@pytest.mark.asyncio
+async def test_rotation_is_notified_when_google_body_read_fails():
+    """Set-Cookie is already authoritative when the body read then fails.
+
+    The client applies the rotated cookies before awaiting the response body,
+    so a failure there would otherwise leave the config entry holding a set
+    Google has already superseded.
+    """
+    client = NestClient(session=_RotatingThenFailingSession())
+    client.issue_token = "https://accounts.google.com/issue"
+    client.cookies = "SID=old"
+    client.nest_session = _make_nest_response(expired=False)
+
+    manager = NestSessionManager(client=client, store=MagicMock())
+    manager.on_credentials_refreshed = MagicMock()
+
+    with pytest.raises(PynestException):
+        await manager.ensure_session()
+
+    assert client.refreshed_cookies == "SID=new"
+    manager.on_credentials_refreshed.assert_called_once_with()
+    assert manager._refresh_lock.locked() is False

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -666,11 +666,15 @@ async def test_refresh_notifies_caller_to_persist_rotated_cookies():
     client.auth = expired_auth
     client.transport_url = None
     client.authenticate = AsyncMock()
+    # Explicitly nothing rotated yet, so the assertion below can't pass on an
+    # auto-created truthy attribute.
+    client.refreshed_cookies = None
 
     def refresh(*args, **kwargs):
         fresh = MagicMock(access_token="fresh")
         fresh.is_expired = MagicMock(return_value=False)
         client.auth = fresh
+        client.refreshed_cookies = "SID=rotated"
 
     client.get_access_token = AsyncMock(side_effect=refresh)
 


### PR DESCRIPTION
## The problem

#555 made the integration keep and persist the cookies Google rotates. That part is correct, but it can only act on a rotation that actually happens — and on the happy path one never does.

Rotated cookies are captured inside `get_access_token_from_cookies()`, which is reached only via `async_refresh_session()`, which `ensure_session()` calls only once the **Nest** session has expired. Nest issues sessions lasting weeks despite `authenticate()` requesting `"expire_after": "3600s"` — on my install, authenticated 2026-08-09 with `expires_in` 2026-09-08. So `ensure_session()` returns early for that entire period and the cookies are never exercised.

Confirmed on a live install: the session store was written once, at re-authentication, and not again across 21 hours of healthy operation.

Google rotates the auth cookies on a far shorter cycle and only honours superseded values for a limited grace window. By the time anything does need Google again — a 401, or a restart — the stored set is long dead, Google answers `USER_LOGGED_OUT`, and the integration forces a re-auth. That matches the re-auth reports in #481, #519, #526 and #530, which #555 alone doesn't resolve.

## The change

Split the Google refresh into `ensure_google_credentials()` and drive it from the access token's own ~1h expiry, independent of Nest session validity.

- The refresh time is persisted alongside the session, so a restart can't keep postponing it.
- A store written before this key existed is assumed fresh and written back, preserving the existing "skip Google entirely" startup path from #486.
- `async_refresh_session()` bypasses the interval — it's the 401 recovery path.

Four further defects surfaced while reviewing this, each of which would have undermined it:

- `NestClient.get_access_token()` preferred a legacy `refresh_token` over cookies, the opposite of the session manager's own precedence. A re-authenticated entry keeps its old `refresh_token` alongside the new cookies, so the hourly refresh would have exercised the stale credential and never the cookies.
- The refresh wasn't serialized. The subscriber, entity updates and the lock observer share one manager; concurrent refreshes would each rotate the cookies while only the last response survived, and would authenticate against Nest twice.
- Cookies rotated during startup, or before a failed/cancelled Nest call, never reached the config entry. Persistence is now keyed on the cookies actually captured from `Set-Cookie` and runs from a `finally`, because the client applies them before it reads the response body.
- Entity-triggered refreshes had no persistence step at all. All paths now report back through `on_credentials_refreshed`.

## Testing

`151 passed, 2 skipped`; ruff clean. Each behavioural fix has a regression test that fails without it.

Supersedes #542, which I'll close — it addressed the same symptom but rested on the same incorrect assumption about refresh cadence as the commit message in #555.

Worth flagging separately for anyone still seeing daily re-auth after this: cookies captured from Chrome are device-bound under [DBSC](https://developer.chrome.com/docs/web-platform/device-bound-session-credentials) and fail Google's handshake regardless of this fix. Capturing from Firefox or Safari avoids it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)