### PR TITLE
feat: Add Smoke/CO status enum sensors

### DIFF
--- a/custom_components/nest_protect/sensor.py
+++ b/custom_components/nest_protect/sensor.py
@@ -23,7 +23,6 @@ from .entity import NestDescriptiveEntity
 from .lock import NestLockBatterySensor, subscribe_to_lock_discovery
 from .pynest.enums import BucketType
 
-
 SMOKE_CO_STATUS_TO_STATE: dict[int, str] = {
     0: "ok",
     1: "testing",
@@ -140,6 +139,7 @@ SENSOR_DESCRIPTIONS: list[NestProtectSensorDescription] = [
         value_fn=smoke_co_status_to_state,
         device_class=SensorDeviceClass.ENUM,
         options=["ok", "testing", "warning", "emergency"],
+        icon="mdi:smoke",
     ),
     NestProtectSensorDescription(
         key="co_status",
@@ -147,6 +147,7 @@ SENSOR_DESCRIPTIONS: list[NestProtectSensorDescription] = [
         value_fn=smoke_co_status_to_state,
         device_class=SensorDeviceClass.ENUM,
         options=["ok", "testing", "warning", "emergency"],
+        icon="mdi:molecule-co",
     ),
     # TODO Add Color Status (gray, green, yellow, red)
 ]

--- a/custom_components/nest_protect/sensor.py
+++ b/custom_components/nest_protect/sensor.py
@@ -24,6 +24,19 @@ from .lock import NestLockBatterySensor, subscribe_to_lock_discovery
 from .pynest.enums import BucketType
 
 
+SMOKE_CO_STATUS_TO_STATE: dict[int, str] = {
+    0: "ok",
+    1: "testing",
+    2: "warning",
+    3: "emergency",
+}
+
+
+def smoke_co_status_to_state(state: int) -> str:
+    """Convert the raw smoke/CO status code to an enum state."""
+    return SMOKE_CO_STATUS_TO_STATE.get(state, "ok")
+
+
 def milli_volt_to_percentage(state: int):
     """
     Convert battery level in mV to a percentage.
@@ -121,9 +134,21 @@ SENSOR_DESCRIPTIONS: list[NestProtectSensorDescription] = [
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    NestProtectSensorDescription(
+        key="smoke_status",
+        translation_key="smoke_status_sensor",
+        value_fn=smoke_co_status_to_state,
+        device_class=SensorDeviceClass.ENUM,
+        options=["ok", "testing", "warning", "emergency"],
+    ),
+    NestProtectSensorDescription(
+        key="co_status",
+        translation_key="co_status_sensor",
+        value_fn=smoke_co_status_to_state,
+        device_class=SensorDeviceClass.ENUM,
+        options=["ok", "testing", "warning", "emergency"],
+    ),
     # TODO Add Color Status (gray, green, yellow, red)
-    # TODO Smoke Status (OK, Warning, Emergency)
-    # TODO CO Status (OK, Warning, Emergency)
 ]
 
 

--- a/custom_components/nest_protect/strings.json
+++ b/custom_components/nest_protect/strings.json
@@ -116,6 +116,24 @@
       },
       "current_temperature": {
         "name": "Temperature"
+      },
+      "smoke_status_sensor": {
+        "name": "Smoke status",
+        "state": {
+          "ok": "OK",
+          "testing": "Testing",
+          "warning": "Warning",
+          "emergency": "Emergency"
+        }
+      },
+      "co_status_sensor": {
+        "name": "CO status",
+        "state": {
+          "ok": "OK",
+          "testing": "Testing",
+          "warning": "Warning",
+          "emergency": "Emergency"
+        }
       }
     },
     "select": {

--- a/custom_components/nest_protect/strings.json
+++ b/custom_components/nest_protect/strings.json
@@ -118,7 +118,7 @@
         "name": "Temperature"
       },
       "smoke_status_sensor": {
-        "name": "Smoke status",
+        "name": "Smoke status (text)",
         "state": {
           "ok": "OK",
           "testing": "Testing",
@@ -127,7 +127,7 @@
         }
       },
       "co_status_sensor": {
-        "name": "CO status",
+        "name": "CO status (text)",
         "state": {
           "ok": "OK",
           "testing": "Testing",

--- a/custom_components/nest_protect/translations/en.json
+++ b/custom_components/nest_protect/translations/en.json
@@ -116,6 +116,24 @@
       },
       "current_temperature": {
         "name": "Temperature"
+      },
+      "smoke_status_sensor": {
+        "name": "Smoke status",
+        "state": {
+          "ok": "OK",
+          "testing": "Testing",
+          "warning": "Warning",
+          "emergency": "Emergency"
+        }
+      },
+      "co_status_sensor": {
+        "name": "CO status",
+        "state": {
+          "ok": "OK",
+          "testing": "Testing",
+          "warning": "Warning",
+          "emergency": "Emergency"
+        }
       }
     },
     "select": {

--- a/custom_components/nest_protect/translations/en.json
+++ b/custom_components/nest_protect/translations/en.json
@@ -118,7 +118,7 @@
         "name": "Temperature"
       },
       "smoke_status_sensor": {
-        "name": "Smoke status",
+        "name": "Smoke status (text)",
         "state": {
           "ok": "OK",
           "testing": "Testing",
@@ -127,7 +127,7 @@
         }
       },
       "co_status_sensor": {
-        "name": "CO status",
+        "name": "CO status (text)",
         "state": {
           "ok": "OK",
           "testing": "Testing",

--- a/custom_components/nest_protect/translations/nl.json
+++ b/custom_components/nest_protect/translations/nl.json
@@ -116,6 +116,24 @@
       },
       "current_temperature": {
         "name": "Temperatuur"
+      },
+      "smoke_status_sensor": {
+        "name": "Rookstatus",
+        "state": {
+          "ok": "OK",
+          "testing": "Testen",
+          "warning": "Waarschuwing",
+          "emergency": "Noodgeval"
+        }
+      },
+      "co_status_sensor": {
+        "name": "CO-status",
+        "state": {
+          "ok": "OK",
+          "testing": "Testen",
+          "warning": "Waarschuwing",
+          "emergency": "Noodgeval"
+        }
       }
     },
     "select": {

--- a/custom_components/nest_protect/translations/nl.json
+++ b/custom_components/nest_protect/translations/nl.json
@@ -118,7 +118,7 @@
         "name": "Temperatuur"
       },
       "smoke_status_sensor": {
-        "name": "Rookstatus",
+        "name": "Rookstatus (tekst)",
         "state": {
           "ok": "OK",
           "testing": "Testen",
@@ -127,7 +127,7 @@
         }
       },
       "co_status_sensor": {
-        "name": "CO-status",
+        "name": "CO-status (tekst)",
         "state": {
           "ok": "OK",
           "testing": "Testen",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,60 @@
+"""Tests for the Nest Protect sensor platform."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.nest_protect.pynest.models import Bucket
+from custom_components.nest_protect.sensor import (
+    SENSOR_DESCRIPTIONS,
+    NestProtectSensor,
+    smoke_co_status_to_state,
+)
+
+AREAS = {"where.living-room": "Living Room"}
+
+
+def build_sensor(
+    key: str, value: dict, object_key: str = "topaz.1234"
+) -> NestProtectSensor:
+    """Build a NestProtectSensor for the given entity description key."""
+    bucket = Bucket(
+        object_key=object_key,
+        object_revision=1,
+        object_timestamp=1,
+        value=value,
+    )
+    description = next(d for d in SENSOR_DESCRIPTIONS if d.key == key)
+    return NestProtectSensor(
+        bucket=bucket,
+        description=description,
+        areas=AREAS,
+        client=MagicMock(),
+    )
+
+
+@pytest.mark.parametrize(
+    ("code", "expected"),
+    [(0, "ok"), (1, "testing"), (2, "warning"), (3, "emergency"), (99, "ok")],
+)
+def test_smoke_co_status_to_state(code: int, expected: str):
+    """Test that raw status codes map to the documented enum states, with an unknown code falling back to ok."""
+    assert smoke_co_status_to_state(code) == expected
+
+
+@pytest.mark.parametrize(
+    ("key", "code", "expected"),
+    [
+        ("smoke_status", 0, "ok"),
+        ("smoke_status", 1, "testing"),
+        ("smoke_status", 2, "warning"),
+        ("smoke_status", 3, "emergency"),
+        ("co_status", 0, "ok"),
+        ("co_status", 2, "warning"),
+        ("co_status", 3, "emergency"),
+    ],
+)
+def test_smoke_and_co_status_sensor_native_value(key: str, code: int, expected: str):
+    """Test that the smoke_status/co_status enum sensors surface the mapped state."""
+    sensor = build_sensor(key, {key: code})
+    assert sensor.native_value == expected


### PR DESCRIPTION
## Change

Add Smoke/CO status enum sensors (OK/Warning/Emergency) closes #56 

Implements the simplest version of the pitch in the issue, which is to expose `smoke_status` and `co_status` as `sensor.enum` entities with ok/warning/emergency states, in addition to the existing binary sensors.

I added the unit tests just to be thorough, but happy to remove if you don't think they earn their keep.

## Questions

I wasn't sure if it was worth updating the "legacy" translations or not, so just did the newer dir to start.

## Live Testing

Looking good testing on my HA instance:

<img width="423" height="432" alt="image" src="https://github.com/user-attachments/assets/da0b394f-75c4-4fc8-9865-f341c8967db3" />

<img width="559" height="505" alt="image" src="https://github.com/user-attachments/assets/b4d3bfb4-c1c8-4976-b9a8-fc39f5a6d3e1" />

<img width="564" height="504" alt="image" src="https://github.com/user-attachments/assets/3a0c2112-0f6c-4345-a6d2-cac91751ace7" />

