### PR TITLE
Keep background updates alive when authentication recovery fails

### DIFF
--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -212,13 +212,8 @@ async def _async_observe_locks_loop(hass: HomeAssistant, entry: ConfigEntry) -> 
                 "Lock observer: credentials rejected (%r), refreshing session", err
             )
             await asyncio.sleep(sm.backoff_interval)
-            await sm.async_refresh_session()
-
-            # Entry may have been unloaded during the backoff sleep
-            if entry.entry_id not in hass.data.get(DOMAIN, {}):
+            if not await _async_recover_session(hass, entry, entry_data):
                 return
-
-            _persist_refreshed_cookies(hass, entry, entry_data.client, sm)
         except Exception:
             LOGGER.exception("Lock observe loop failed unexpectedly")
             return
@@ -279,6 +274,35 @@ def _persist_refreshed_cookies(
         data={**entry.data, CONF_COOKIES: new_cookies},
     )
     client.cookies = new_cookies
+
+
+async def _async_recover_session(
+    hass: HomeAssistant, entry: ConfigEntry, entry_data: HomeAssistantNestProtectData
+) -> bool:
+    """Refresh rejected credentials and report whether background work can resume."""
+    if entry.entry_id not in hass.data.get(DOMAIN, {}):
+        return False
+
+    # Exceptions raised inside a transport's except block bypass its other handlers.
+    try:
+        await entry_data.session_manager.async_refresh_session()
+    except BadCredentialsException:
+        entry.async_start_reauth(hass)
+        return False
+    except (
+        TimeoutError,
+        ClientError,
+        NestServiceException,
+        NotAuthenticatedException,
+        PynestException,
+    ) as err:
+        LOGGER.debug("Session recovery failed; retrying background updates: %s", err)
+
+    if entry.entry_id not in hass.data.get(DOMAIN, {}):
+        return False
+
+    _persist_refreshed_cookies(hass, entry, entry_data.client, entry_data.session_manager)
+    return True
 
 
 def _register_subscribe_task(
@@ -406,13 +430,8 @@ async def _async_subscribe_for_data(
         )
         await asyncio.sleep(sm.backoff_interval)
 
-        await sm.async_refresh_session()
-
-        # Entry may have been unloaded during the backoff sleep
-        if entry.entry_id not in hass.data.get(DOMAIN, {}):
+        if not await _async_recover_session(hass, entry, entry_data):
             return
-
-        _persist_refreshed_cookies(hass, entry, entry_data.client, sm)
 
         _register_subscribe_task(hass, entry, data)
 

--- a/custom_components/nest_protect/__init__.py
+++ b/custom_components/nest_protect/__init__.py
@@ -301,7 +301,9 @@ async def _async_recover_session(
     if entry.entry_id not in hass.data.get(DOMAIN, {}):
         return False
 
-    _persist_refreshed_cookies(hass, entry, entry_data.client, entry_data.session_manager)
+    _persist_refreshed_cookies(
+        hass, entry, entry_data.client, entry_data.session_manager
+    )
     return True
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,6 @@
 """Test init."""
 
+import asyncio
 import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -11,10 +12,17 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.nest_protect import (
     DOMAIN,
     HomeAssistantNestProtectData,
+    _async_observe_locks_loop,
     _async_subscribe_for_data,
 )
 from custom_components.nest_protect.const import CONF_COOKIES, MAX_AUTH_FAILURES
-from custom_components.nest_protect.pynest.exceptions import NotAuthenticatedException
+from custom_components.nest_protect.pynest.exceptions import (
+    BadCredentialsException,
+    NestLockAuthException,
+    NestServiceException,
+    NotAuthenticatedException,
+    PynestException,
+)
 from custom_components.nest_protect.session import NestSessionManager
 
 from .conftest import COOKIES, ISSUE_TOKEN, ComponentSetup
@@ -490,3 +498,86 @@ async def test_subscriber_success_resets_failure_counter(hass):
         await _async_subscribe_for_data(hass, entry, _make_subscribe_data())
 
     assert sm.consecutive_failures == 0
+
+
+@pytest.mark.parametrize("transport", ["subscriber", "lock"])
+@pytest.mark.parametrize(
+    ("refresh_error", "reauth_expected"),
+    [
+        (aiohttp.ClientError("offline"), False),
+        (TimeoutError(), False),
+        (PynestException("temporary"), False),
+        (NestServiceException("unavailable"), False),
+        (NotAuthenticatedException("rejected"), False),
+        (BadCredentialsException("revoked"), True),
+    ],
+)
+async def test_auth_recovery_handles_refresh_errors(
+    hass, transport, refresh_error, reauth_expected
+):
+    """A failed refresh must retry or request reauth without killing the task."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+    client, sm = _make_subscriber_entry_data(hass, entry)
+    client.subscribe_for_data = AsyncMock(side_effect=NotAuthenticatedException())
+
+    attempts = []
+
+    async def observe_locks():
+        attempts.append(True)
+        if len(attempts) == 1:
+            raise NestLockAuthException("rejected")
+        yield {}
+
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    entry_data.grpc_lock_client.observe_locks = observe_locks
+    with (
+        patch("custom_components.nest_protect._register_subscribe_task") as reschedule,
+        patch.object(sm, "ensure_session", new_callable=AsyncMock),
+        patch.object(sm, "async_refresh_session", side_effect=refresh_error),
+        patch(
+            "custom_components.nest_protect.asyncio.sleep", new_callable=AsyncMock
+        ) as sleep,
+        patch.object(entry, "async_start_reauth") as reauth,
+    ):
+        if transport == "subscriber":
+            await _async_subscribe_for_data(hass, entry, _make_subscribe_data())
+            assert reschedule.call_count == (0 if reauth_expected else 1)
+        else:
+            await _async_observe_locks_loop(hass, entry)
+            assert len(attempts) == (1 if reauth_expected else 2)
+
+    assert reauth.call_count == int(reauth_expected)
+    assert any(call.args[0] > 0 for call in sleep.call_args_list)
+
+
+@pytest.mark.parametrize("transport", ["subscriber", "lock"])
+async def test_auth_recovery_cancellation_does_not_restart(hass, transport):
+    """Unloading during a refresh must cancel without starting more work."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+    client, sm = _make_subscriber_entry_data(hass, entry)
+    client.subscribe_for_data = AsyncMock(side_effect=NotAuthenticatedException())
+
+    async def observe_locks():
+        yield {}
+        raise NestLockAuthException("rejected")
+
+    hass.data[DOMAIN][entry.entry_id].grpc_lock_client.observe_locks = observe_locks
+    with (
+        patch("custom_components.nest_protect._register_subscribe_task") as reschedule,
+        patch.object(sm, "ensure_session", new_callable=AsyncMock),
+        patch.object(
+            sm, "async_refresh_session", side_effect=asyncio.CancelledError()
+        ),
+        patch("custom_components.nest_protect.asyncio.sleep", new_callable=AsyncMock),
+        patch.object(entry, "async_start_reauth") as reauth,
+        pytest.raises(asyncio.CancelledError),
+    ):
+        if transport == "subscriber":
+            await _async_subscribe_for_data(hass, entry, _make_subscribe_data())
+        else:
+            await _async_observe_locks_loop(hass, entry)
+
+    reschedule.assert_not_called()
+    reauth.assert_not_called()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -564,20 +564,20 @@ async def test_auth_recovery_cancellation_does_not_restart(hass, transport):
         raise NestLockAuthException("rejected")
 
     hass.data[DOMAIN][entry.entry_id].grpc_lock_client.observe_locks = observe_locks
+    operation = (
+        _async_subscribe_for_data(hass, entry, _make_subscribe_data())
+        if transport == "subscriber"
+        else _async_observe_locks_loop(hass, entry)
+    )
     with (
         patch("custom_components.nest_protect._register_subscribe_task") as reschedule,
         patch.object(sm, "ensure_session", new_callable=AsyncMock),
-        patch.object(
-            sm, "async_refresh_session", side_effect=asyncio.CancelledError()
-        ),
+        patch.object(sm, "async_refresh_session", side_effect=asyncio.CancelledError()),
         patch("custom_components.nest_protect.asyncio.sleep", new_callable=AsyncMock),
         patch.object(entry, "async_start_reauth") as reauth,
         pytest.raises(asyncio.CancelledError),
     ):
-        if transport == "subscriber":
-            await _async_subscribe_for_data(hass, entry, _make_subscribe_data())
-        else:
-            await _async_observe_locks_loop(hass, entry)
+        await operation
 
     reschedule.assert_not_called()
     reauth.assert_not_called()


### PR DESCRIPTION
After Nest rejects a subscription, the REST subscriber and lock observer refresh authentication inside their exception handlers. If that refresh also fails, its exception escapes the surrounding handlers and ends background updates until the integration is reloaded.

Handle known refresh failures in a shared recovery helper. Temporary network/service failures resume the existing retry path with backoff; rejected credentials start reauthentication. Cancellation and unload handling are preserved, and rotated cookies are persisted after partial refreshes.

Related to #452, #493, #519 and #63. This fixes a reproducible task-termination path. Broader credential longevity and renewal cadence remain separate work.

Validation:
- Before the fix, all 12 recovery-error cases reproduced escaping exceptions; cancellation controls passed.
- Final GitHub CI: 146 passed, 2 existing skipped tests; all pre-commit checks and hassfest passed.
- Independent private code review found no blocking issue.
- Baseline and initial reproductions ran in the devcontainer. Final validation used GitHub CI after Docker became unavailable.
- No live account or device testing; retained as a draft for maintainer review.
