### PR TITLE
Preserve unknown sensor values and tolerate missing power metadata

### DIFF
--- a/custom_components/nest_protect/binary_sensor.py
+++ b/custom_components/nest_protect/binary_sensor.py
@@ -180,7 +180,10 @@ async def async_setup_entry(hass, entry, async_add_devices):
         for key in device.value:
             if description := supported_keys.get(key):
                 # Not all entities are useful for battery powered Nest Protect devices
-                if description.wired_only and device.value["wired_or_battery"] != 0:
+                if (
+                    description.wired_only
+                    and device.value.get("wired_or_battery") != 0
+                ):
                     continue
 
                 entities.append(
@@ -198,7 +201,9 @@ class NestProtectBinarySensor(NestDescriptiveEntity, BinarySensorEntity):
     entity_description: NestProtectBinarySensorDescription
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return the state of the sensor."""
         state = self.bucket.value.get(self.entity_description.key)
+        if state is None:
+            return None
         return self.entity_description.value_fn(state)

--- a/custom_components/nest_protect/binary_sensor.py
+++ b/custom_components/nest_protect/binary_sensor.py
@@ -180,10 +180,7 @@ async def async_setup_entry(hass, entry, async_add_devices):
         for key in device.value:
             if description := supported_keys.get(key):
                 # Not all entities are useful for battery powered Nest Protect devices
-                if (
-                    description.wired_only
-                    and device.value.get("wired_or_battery") != 0
-                ):
+                if description.wired_only and device.value.get("wired_or_battery") != 0:
                     continue
 
                 entities.append(

--- a/custom_components/nest_protect/sensor.py
+++ b/custom_components/nest_protect/sensor.py
@@ -158,9 +158,11 @@ class NestProtectSensor(NestDescriptiveEntity, SensorEntity):
     entity_description: NestProtectSensorDescription
 
     @property
-    def native_value(self) -> bool:
+    def native_value(self) -> StateType:
         """Return the state of the sensor."""
         state = self.bucket.value.get(self.entity_description.key)
+        if state is None:
+            return None
 
         if self.entity_description.value_fn:
             return self.entity_description.value_fn(state)

--- a/custom_components/nest_protect/sensor.py
+++ b/custom_components/nest_protect/sensor.py
@@ -158,7 +158,7 @@ class NestProtectSensor(NestDescriptiveEntity, SensorEntity):
     entity_description: NestProtectSensorDescription
 
     @property
-    def native_value(self) -> StateType:
+    def native_value(self) -> StateType | datetime.datetime:
         """Return the state of the sensor."""
         state = self.bucket.value.get(self.entity_description.key)
         if state is None:

--- a/tests/test_sparse_data.py
+++ b/tests/test_sparse_data.py
@@ -30,9 +30,7 @@ def test_missing_binary_values_remain_unknown(key, missing):
     """Missing samples must not be converted into an alarm or occupancy."""
     description = next(d for d in BINARY_SENSOR_DESCRIPTIONS if d.key == key)
     payload = {} if missing else {key: None}
-    entity = NestProtectBinarySensor(
-        make_bucket(payload), description, {}, MagicMock()
-    )
+    entity = NestProtectBinarySensor(make_bucket(payload), description, {}, MagicMock())
     assert entity.is_on is None
 
 

--- a/tests/test_sparse_data.py
+++ b/tests/test_sparse_data.py
@@ -1,0 +1,97 @@
+"""Tests for sparse Nest Protect device responses."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.nest_protect.binary_sensor import (
+    BINARY_SENSOR_DESCRIPTIONS,
+    NestProtectBinarySensor,
+    async_setup_entry,
+)
+from custom_components.nest_protect.const import DOMAIN
+from custom_components.nest_protect.pynest.enums import BucketType
+from custom_components.nest_protect.pynest.models import Bucket
+from custom_components.nest_protect.sensor import (
+    SENSOR_DESCRIPTIONS,
+    NestProtectSensor,
+)
+
+
+def make_bucket(value):
+    """Make a device response without optional identity metadata."""
+    return Bucket("topaz.test", 1, 1, value)
+
+
+@pytest.mark.parametrize("key", ["smoke_status", "co_status", "auto_away"])
+@pytest.mark.parametrize("missing", [False, True])
+def test_missing_binary_values_remain_unknown(key, missing):
+    """Missing samples must not be converted into an alarm or occupancy."""
+    description = next(d for d in BINARY_SENSOR_DESCRIPTIONS if d.key == key)
+    payload = {} if missing else {key: None}
+    entity = NestProtectBinarySensor(
+        make_bucket(payload), description, {}, MagicMock()
+    )
+    assert entity.is_on is None
+
+
+@pytest.mark.parametrize(
+    "key", ["battery_level", "current_temperature", "replace_by_date_utc_secs"]
+)
+@pytest.mark.parametrize("missing", [False, True])
+def test_missing_numeric_values_remain_unknown(key, missing):
+    """Missing numeric/date samples must not raise during state writes."""
+    description = next(
+        d
+        for d in SENSOR_DESCRIPTIONS
+        if d.key == key and d.bucket_type != BucketType.KRYPTONITE
+    )
+    entity = NestProtectSensor(
+        make_bucket({} if missing else {key: None}), description, {}, MagicMock()
+    )
+    assert entity.native_value is None
+
+
+@pytest.mark.parametrize("missing", [False, True])
+async def test_unknown_power_source_does_not_abort_binary_platform(hass, missing):
+    """A sparse Protect must still expose its supported alarm sensors."""
+    payload = {
+        "smoke_status": 0,
+        "auto_away": False,
+        "line_power_present": True,
+    }
+    if not missing:
+        payload["wired_or_battery"] = None
+    device = make_bucket(payload)
+    entry = SimpleNamespace(entry_id="test")
+    hass.data[DOMAIN] = {
+        entry.entry_id: SimpleNamespace(
+            devices={device.object_key: device}, areas={}, client=MagicMock()
+        )
+    }
+    add_entities = MagicMock()
+
+    await async_setup_entry(hass, entry, add_entities)
+
+    entities = add_entities.call_args.args[0]
+    assert [entity.entity_description.key for entity in entities] == ["smoke_status"]
+    assert entities[0].is_on is False
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "expected"),
+    [
+        ("smoke_status", 0, False),
+        ("smoke_status", 2, True),
+        ("co_status", 3, True),
+        ("auto_away", False, True),
+    ],
+)
+def test_present_binary_values_keep_existing_meaning(key, value, expected):
+    """Preserve the meaning of real alarm and occupancy samples."""
+    description = next(d for d in BINARY_SENSOR_DESCRIPTIONS if d.key == key)
+    entity = NestProtectBinarySensor(
+        make_bucket({key: value}), description, {}, MagicMock()
+    )
+    assert entity.is_on is expected


### PR DESCRIPTION
Sparse Nest responses could turn absent/null smoke and CO values into detected alarms, missing occupancy into occupied, and missing numeric/date values into conversion exceptions. A Protect without wired_or_battery could also abort binary-sensor platform setup.

Return unknown before converting missing values, and skip wired-only entities when the power source is unknown. Other supported entities still load, and real zero/false values retain their existing meaning.

Related to #516 and #73. This handles incomplete device data; it does not reconstruct entirely absent Topaz buckets or restore missing firmware telemetry.

Validation:
- Before the fix, CI reproduced 13 expected failures: six incorrect binary states, six numeric/date conversion errors, and one missing-power-key setup crash.
- Final GitHub CI: 150 passed, 2 existing skipped tests; all pre-commit checks and hassfest passed.
- Independent private review found no correctness blocker.
- No live account or device testing; retained as a draft for maintainer review.
